### PR TITLE
Fill regions on 'F' key (https://github.com/Fish1/yapms-beta/issues/7)

### DIFF
--- a/client/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/client/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -23,6 +23,7 @@
 	};
 
 	let mode: Mode = 'fill';
+	let fillKeyPressed: boolean = false;
 
 	let currentMap = 'usa' as keyof typeof imports;
 	let mapBind: HTMLDivElement;
@@ -206,8 +207,24 @@
 		return mode;
 	}
 
-	function fillRegion(region: HTMLElement) {
-		candidates = _fillRegion(mapBind, region, selectedCandidateId, candidates, true);
+	function getFillKeyPressed() {
+		return fillKeyPressed;
+	}
+
+	function handleKeyDown(e: KeyboardEvent) {
+		if (e.code === 'KeyF') { //Fill button
+			fillKeyPressed = true;
+		}
+	}
+
+	function handleKeyUp(e: KeyboardEvent) {
+		if (e.code === 'KeyF') { //Fill button
+			fillKeyPressed = false;
+		}
+	}
+
+	function fillRegion(region: HTMLElement, increment:boolean) {
+		candidates = _fillRegion(mapBind, region, selectedCandidateId, candidates, increment);
 	}
 
 	function editRegion(shortName: string, newValues: { newValue: number }) {
@@ -220,10 +237,13 @@
 	function setupMap(node: HTMLDivElement) {
 		panZoom = applyPanZoom(node);
 		candidates = initializeMap(node, candidates);
-		setupRegions(node, fillRegion, getMode, openEditStateModal);
-		setupButtons(node, fillRegion, getMode);
+		setupRegions(node, fillRegion, getMode, getFillKeyPressed, openEditStateModal);
+		setupButtons(node, fillRegion, getMode, getFillKeyPressed);
 	}
 </script>
+
+<!--Tell Svelte to use the handleKeyDown function when any key pressed and handleKeyUp when key released-->
+<svelte:window on:keydown={handleKeyDown} on:keyup={handleKeyUp}/>
 
 <div class="flex flex-col h-full">
 	<NavBar

--- a/client/src/routes/app/[country]/[map]/[year]/initialize.ts
+++ b/client/src/routes/app/[country]/[map]/[year]/initialize.ts
@@ -70,8 +70,9 @@ function initializeMap(mapBind: HTMLDivElement, candidates: Candidate[]) {
 
 function setupRegions(
 	mapBind: HTMLDivElement,
-	fillRegion: (region: HTMLElement) => void,
+	fillRegion: (region: HTMLElement, increment: boolean) => void,
 	getMode: () => string,
+	getFillKeyPressed: () => boolean,
 	openEditStateModal: (state: State) => void
 ) {
 	const regions = mapBind.querySelector('.regions');
@@ -80,7 +81,7 @@ function setupRegions(
 		const regionDom = region as HTMLElement;
 		regionDom.onclick = () => {
 			if (getMode() === 'fill') {
-				fillRegion(regionDom);
+				fillRegion(regionDom, true);
 			} else if (getMode() === 'edit') {
 				const shortName = regionDom.getAttribute('short-name') ?? '';
 				const longName = regionDom.getAttribute('short-name') ?? '';
@@ -92,13 +93,19 @@ function setupRegions(
 				});
 			}
 		};
+		regionDom.onmouseover = () => {
+			if(getFillKeyPressed() && getMode() === 'fill') {
+				fillRegion(regionDom, false);
+			}
+		}
 	});
 }
 
 function setupButtons(
 	mapBind: HTMLDivElement,
-	fillRegion: (a: HTMLElement) => void,
-	getMode: () => string
+	fillRegion: (a: HTMLElement, increment: boolean) => void,
+	getMode: () => string,
+	getFillKeyPressed: () => boolean
 ) {
 	const buttons = mapBind.querySelector('.region-buttons');
 	if (buttons === null) return;
@@ -108,9 +115,16 @@ function setupButtons(
 			const forRegion = buttonDom.getAttribute('for');
 			const region = mapBind.querySelector(`[short-name="${forRegion}"]`);
 			if (region && getMode() === 'fill') {
-				fillRegion(region as HTMLElement);
+				fillRegion(region as HTMLElement, true);
 			}
 		};
+		buttonDom.onmouseover = () => {
+			const forRegion = buttonDom.getAttribute('for');
+			const region = mapBind.querySelector(`[short-name="${forRegion}"]`);
+			if(region && getFillKeyPressed() && getMode() === 'fill') {
+				fillRegion(region as HTMLElement, false);
+			}
+		}
 	});
 }
 


### PR DESCRIPTION
To use:
Hold 'F'
Drag cursor across map
![yapmsFill](https://user-images.githubusercontent.com/42476312/204160089-71de43e1-2709-4e9c-b26b-ef766977a491.gif)

Works on buttons as well.

Summary of code changes:
- Adds fillKeyPressed boolean variable to map page along with a get method.
- Adds handler methods for keyDown and keyUp events. Necessary to track whether F key is currently pressed.
- Adds methods to run onmouseover for states and map buttons.
- Changes fillRegion function in map page to no longer assume increment parameter is true, changes setupRegions and setupButtons methods in initialize.ts to accommodate. This is necessary to prevent behavior where mousing over a state twice while filling will "double fill" and change margin (see gif below).
![yapmsDoubleFill](https://user-images.githubusercontent.com/42476312/204160360-3283e1aa-ac5a-49bd-9693-1e592735450f.gif)


Closes #7.
Please let me know if you need more documentation.