### PR TITLE
Fix to odd pie chart behavior

### DIFF
--- a/client/src/lib/components/chartbar/ChartBar.svelte
+++ b/client/src/lib/components/chartbar/ChartBar.svelte
@@ -14,9 +14,9 @@
 		const labels: string[] = [];
 
 		$CandidatesStore.forEach((candidate) => {
-			const count = $CandidateCounts.get(candidate.id);
+			let count = $CandidateCounts.get(candidate.id);
 			if (count === undefined) {
-				return;
+				count = 0;
 			}
 			counts.push(count);
 			colors.push(candidate.margins[0].color);


### PR DESCRIPTION
Changes pie chart behavior to make transitions more smooth.
![yapmsFixedPie](https://user-images.githubusercontent.com/42476312/205820363-011d2322-d245-47de-b935-0cffa6533e7b.gif)

Why does this work?
Basically, passing undefined to the counts array doesn't add anything. This means the number of elements in the array is constantly changing. This means that the pie chart has to re-render in order to add a new element for the candidate's "slice".

If we have all the candidate slices render by keeping the counts array length == # of candidates, but just set the size of them to 0 if the candidate has 0 EV's, then the size of these slices can be readjusted instead of the chart re-rendering completely. Chart should in theory still re-render when a candidate is added or deleted since the counts array length will change.

Closes #22.
Tested using Docker & Local