### PR TITLE
Quick fill fix

### DIFF
--- a/client/src/lib/stores/Interaction.ts
+++ b/client/src/lib/stores/Interaction.ts
@@ -1,4 +1,4 @@
 import { writable } from 'svelte/store';
-/*The array here is an array of keys pressed by code (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code). 
-Limited to key presses relevant to functionality through checks where the store is modified.*/
-export const InteractionStore = writable<Array<String>>([]);
+/*The map here is a map of keys pressed by code (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code). 
+Key presses are set to true when pressed and then deleted from the map when released.*/
+export const InteractionStore = writable<Map<string, boolean>>(new Map<string,boolean>);

--- a/client/src/lib/stores/Interaction.ts
+++ b/client/src/lib/stores/Interaction.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+/*The array here is an array of keys pressed by code (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code). 
+Limited to key presses relevant to functionality through checks where the store is modified.*/
+export const InteractionStore = writable<Array<String>>([]);

--- a/client/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/client/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -11,6 +11,8 @@
 	import ClearMapModal from '$lib/components/modals/clearmapmodal/ClearMapModal.svelte';
 	import applyPanZoom from './initialize/ApplyPanZoom';
 	import EditRegionModal from '$lib/components/modals/editregionmodal/EditRegionModal.svelte';
+	import { get } from 'svelte/store';
+	import { InteractionStore } from '$lib/stores/Interaction';
 
 	const imports = {
 		usa: () => import('$lib/assets/usa.svg?raw'),
@@ -27,11 +29,32 @@
 		applyPanZoom(node);
 		loadRegions(node);
 	}
+
+	//Array of codes for keys used for functionality.
+	const validKeyCodes = ["KeyF"];
+
+	function handleKeyDown(e: KeyboardEvent) {
+		if (validKeyCodes.indexOf(e.code) !== -1) { //Check if key used for functionality
+			let interactions = get(InteractionStore);
+			interactions.push("KeyF");
+			InteractionStore.set(interactions);
+		}
+	}
+
+	function handleKeyUp(e: KeyboardEvent) {
+		if (validKeyCodes.indexOf(e.code) !== -1) { //Check if key used for functionality
+			let interactions = get(InteractionStore);
+			interactions = interactions.filter(code => code !== e.code); //Remove code for key released
+			InteractionStore.set(interactions);
+		}
+	}
 </script>
 
 <svelte:head>
 	<title>YAPms</title>
 </svelte:head>
+
+<svelte:window on:keydown={handleKeyDown} on:keyup={handleKeyUp}></svelte:window>
 
 <div class="flex flex-col h-full">
 	<NavBar />

--- a/client/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/client/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -11,7 +11,6 @@
 	import ClearMapModal from '$lib/components/modals/clearmapmodal/ClearMapModal.svelte';
 	import applyPanZoom from './initialize/ApplyPanZoom';
 	import EditRegionModal from '$lib/components/modals/editregionmodal/EditRegionModal.svelte';
-	import { get } from 'svelte/store';
 	import { InteractionStore } from '$lib/stores/Interaction';
 
 	const imports = {
@@ -30,23 +29,13 @@
 		loadRegions(node);
 	}
 
-	//Array of codes for keys used for functionality.
-	const validKeyCodes = ["KeyF"];
-
 	function handleKeyDown(e: KeyboardEvent) {
-		if (validKeyCodes.indexOf(e.code) !== -1) { //Check if key used for functionality
-			let interactions = get(InteractionStore);
-			interactions.push("KeyF");
-			InteractionStore.set(interactions);
-		}
+		$InteractionStore = $InteractionStore.set(e.code, true); //Set the key code to "true" in the map
 	}
 
 	function handleKeyUp(e: KeyboardEvent) {
-		if (validKeyCodes.indexOf(e.code) !== -1) { //Check if key used for functionality
-			let interactions = get(InteractionStore);
-			interactions = interactions.filter(code => code !== e.code); //Remove code for key released
-			InteractionStore.set(interactions);
-		}
+  		$InteractionStore.delete(e.code); //Remove the key code from the map.. map.delete() returns a boolean??
+		$InteractionStore = $InteractionStore //Tell the store it updated
 	}
 </script>
 

--- a/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
+++ b/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
@@ -4,8 +4,9 @@ import { RegionsStore } from '$lib/stores/Regions';
 import { TossupCandidateStore, SelectedCandidateStore } from '$lib/stores/Candidates';
 import { EditRegionModalStore } from '$lib/stores/Modals';
 import type Region from '$lib/types/Region';
+import { InteractionStore } from '$lib/stores/Interaction';
 
-function fillRegion(regionID: string) {
+function fillRegion(regionID: string, increment?: boolean) {
 	const regions = get(RegionsStore);
 	const region = regions.find((region) => region.id === regionID);
 	if (region) {
@@ -16,7 +17,7 @@ function fillRegion(regionID: string) {
 			count: region.value,
 			margin: 0
 		};
-		if (currentCandidate.candidate.id === selectedCandidate.id) {
+		if (currentCandidate.candidate.id === selectedCandidate.id && increment === true) {
 			newCandidate.margin =
 				currentCandidate.margin + 1 >= selectedCandidate.margins.length
 					? 0
@@ -78,6 +79,15 @@ function loadRegions(node: HTMLDivElement) {
 					break;
 			}
 		};
+
+		childHTML.onmousemove = () => {
+			const currentMode = get(ModeStore);
+			const currentInteractions = get(InteractionStore);
+
+			if(currentMode === 'fill' && currentInteractions.indexOf("KeyF") !== -1) {
+				fillRegion(newRegion.id, false);
+			}
+		}
 
 		newRegion.nodes.region.style.fill = tossupCandidate.margins[0].color;
 		if (newRegion.nodes.button) {

--- a/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
+++ b/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
@@ -84,7 +84,7 @@ function loadRegions(node: HTMLDivElement) {
 			const currentMode = get(ModeStore);
 			const currentInteractions = get(InteractionStore);
 
-			if(currentMode === 'fill' && currentInteractions.indexOf("KeyF") !== -1) {
+			if(currentMode === 'fill' && currentInteractions.has("KeyF") === true) {
 				fillRegion(newRegion.id, false);
 			}
 		}


### PR DESCRIPTION
Quick fill functionality originally implemented before store rework with PR #10 has been readded.
![yapmsFill2](https://user-images.githubusercontent.com/42476312/205970458-e42eae88-fe84-492b-8246-cf05408724ca.gif)

Summary of code changes:
- Creates store (InteractionStore) for keyboard state, uses obtained from [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)
- Adds handler methods for keyDown and keyUp events. Necessary to track whether F key is currently pressed.
- Adds a method to run onmouseover for states and regions.
- Adds optional 'increment' parameter to fillRegion method to stop the "double fill" behavior described in the original PR.

Closes #23 
Tested on Docker & Local