### PR TITLE
Reintroduction of Disabled States

### DIFF
--- a/client/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
+++ b/client/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
@@ -15,7 +15,8 @@
 		const index = $RegionsStore.findIndex(
 			(region) => region.id === $EditRegionModalStore.region?.id
 		);
-		if (!$RegionsStore[index].disabled) { //Don't update value if disabled so the state stays disabled!
+		if (!$RegionsStore[index].disabled) {
+			//Don't update value if disabled so the state stays disabled!
 			$RegionsStore[index].value = newValue;
 		}
 		$RegionsStore[index].permaVal = newValue;

--- a/client/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
+++ b/client/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
@@ -4,7 +4,7 @@
 
 	$: open = $EditRegionModalStore.open;
 	$: longName = open ? $EditRegionModalStore.region?.longName : undefined;
-	$: value = open ? $EditRegionModalStore.region?.value : undefined;
+	$: value = open ? $EditRegionModalStore.region?.permaVal : undefined;
 	$: newValue = value ?? 0;
 
 	function close() {
@@ -15,7 +15,10 @@
 		const index = $RegionsStore.findIndex(
 			(region) => region.id === $EditRegionModalStore.region?.id
 		);
-		$RegionsStore[index].value = newValue;
+		if (!$RegionsStore[index].disabled) { //Don't update value if disabled so the state stays disabled!
+			$RegionsStore[index].value = newValue;
+		}
+		$RegionsStore[index].permaVal = newValue;
 		$EditRegionModalStore.open = false;
 	}
 </script>

--- a/client/src/lib/stores/Regions.ts
+++ b/client/src/lib/stores/Regions.ts
@@ -14,10 +14,16 @@ export const RegionsStore = writable<Region[]>([]);
 */
 RegionsStore.subscribe((regions) => {
 	regions.forEach((region) => {
-		let winner = region.candidates.reduce(
-			(prev, current) => (prev.count > current.count ? prev : current),
-			region.candidates[0]
-		);
+		const winner = region.disabled
+			? {
+					candidate: get(TossupCandidateStore),
+					count: 0,
+					margin: 0
+			  }
+			: region.candidates.reduce(
+					(prev, current) => (prev.count > current.count ? prev : current),
+					region.candidates[0]
+			  );
 		let marginIndex = winner.margin ?? 0;
 		if (marginIndex >= winner.candidate.margins.length) {
 			marginIndex = winner.candidate.margins.length - 1;
@@ -39,10 +45,6 @@ RegionsStore.subscribe((regions) => {
 					}
 				}
 			}
-		}
-		if (region.disabled) {
-			//This is here in order to force a unified style for disabled states.
-			winner = { candidate: get(TossupCandidateStore), count: 0, margin: 0 };
 		}
 
 		region.nodes.region.style.fill = winner.candidate.margins[marginIndex]?.color;

--- a/client/src/lib/stores/Regions.ts
+++ b/client/src/lib/stores/Regions.ts
@@ -1,6 +1,7 @@
 import type Region from '$lib/types/Region';
 import { calculateLumaHEX } from '$lib/utils/luma';
-import { derived, writable } from 'svelte/store';
+import { derived, writable, get } from 'svelte/store';
+import { TossupCandidateStore } from './Candidates';
 
 /**
  * Stores the state of all regions.
@@ -13,7 +14,7 @@ export const RegionsStore = writable<Region[]>([]);
 */
 RegionsStore.subscribe((regions) => {
 	regions.forEach((region) => {
-		const winner = region.candidates.reduce(
+		let winner = region.candidates.reduce(
 			(prev, current) => (prev.count > current.count ? prev : current),
 			region.candidates[0]
 		);
@@ -39,6 +40,11 @@ RegionsStore.subscribe((regions) => {
 				}
 			}
 		}
+		if (region.disabled) {
+			//This is here in order to force a unified style for disabled states.
+			winner = { candidate: get(TossupCandidateStore), count: 0, margin: 0 };
+		}
+
 		region.nodes.region.style.fill = winner.candidate.margins[marginIndex]?.color;
 		if (region.nodes.button)
 			region.nodes.button.style.fill = winner.candidate.margins[marginIndex]?.color;

--- a/client/src/lib/types/Region.ts
+++ b/client/src/lib/types/Region.ts
@@ -5,6 +5,7 @@ type Region = {
 	shortName: string;
 	longName: string;
 	value: number;
+	permaVal: number;
 	disabled: boolean;
 	candidates: Array<{ candidate: Candidate; count: number; margin: number }>;
 	nodes: {

--- a/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
+++ b/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
@@ -64,7 +64,6 @@ function disableRegion(regionID: string) {
 			//Currently Enabled (Disable)
 			region.disabled = true;
 			//Set Region value to 0, save current val for when enabled again.
-			region.permaVal = region.value;
 			region.value = 0;
 
 			//Set to disabled attributes & style


### PR DESCRIPTION
Disabled States functionality originally implemented before store rework with #15 has been readded.
![yapmsDisabledStatesReintro](https://user-images.githubusercontent.com/42476312/208224941-a66c9111-8c91-4785-8702-31438a06a70b.gif)

Changes to feature:
When reenabled, the disabled state will now go back to it's previous fill. This is a deviation from YAPms1 and also creates the need for some potentially suboptimal solutions, such as setting the winner candidate to tossup in the function that handles styling regions. I made the determination this was ok, but it will be easy to reconfigure the feature to work as in YAPms1 if requested.

Summary of Code Changes:
- Creates a new property called "permaVal" within Region type. This value will track with "value" prop unless state is disabled, upon which value will be set to 0 and permaVal will not change. This is used to set state back to proper value when re-enabled. Can't just read this from map attributes in the case that user edit's region values.
- Creates new method disableRegion in initialize. This function either disables or enables the state by setting/removing the disabled attribute, setting styles for both the state and any button associated, and setting the region value to 0 if disabling, permaVal if enabling.
- Adds a disabled check to function that styles regions in order to enforce a consistent style.
- Adds a disabled check when editing region value in order to keep val at 0 if state disabled, edit region also now changes permaVal.

Closes #21.