### PR TITLE
Defining disabled states now possible using map SVG

### DIFF
--- a/client/src/lib/stores/Regions.ts
+++ b/client/src/lib/stores/Regions.ts
@@ -48,8 +48,21 @@ RegionsStore.subscribe((regions) => {
 		}
 
 		region.nodes.region.style.fill = winner.candidate.margins[marginIndex]?.color;
-		if (region.nodes.button)
+		region.disabled
+			? (region.nodes.region.style.fillOpacity = '0.25')
+			: (region.nodes.region.style.fillOpacity = '1'); //Transparent if disabled
+		region.disabled
+			? (region.nodes.region.style.strokeOpacity = '0.25')
+			: (region.nodes.region.style.strokeOpacity = '1'); //Transparent if disabled
+		if (region.nodes.button) {
 			region.nodes.button.style.fill = winner.candidate.margins[marginIndex]?.color;
+			region.disabled
+				? (region.nodes.button.style.fillOpacity = '0.25')
+				: (region.nodes.button.style.fillOpacity = '1'); //Transparent if disabled
+			region.disabled
+				? (region.nodes.button.style.strokeOpacity = '0.25')
+				: (region.nodes.button.style.strokeOpacity = '1'); //Transparent if disabled
+		}
 		if (region.nodes.text) {
 			region.nodes.text.style.color =
 				calculateLumaHEX(winner.candidate.margins[marginIndex]?.color) > 0.5 ? 'black' : 'white';

--- a/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
+++ b/client/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
@@ -49,33 +49,11 @@ function disableRegion(regionID: string) {
 			region.disabled = false;
 			//Set Region value back to OG value
 			region.value = region.permaVal;
-
-			//Set to disabled attributes & style
-			region.nodes.region.style.fillOpacity = '1';
-			region.nodes.region.style.strokeOpacity = '1';
-
-			//Button
-			const button = region.nodes.button;
-			if (button) {
-				button.style.fillOpacity = '1';
-				button.style.strokeOpacity = '1';
-			}
 		} else {
 			//Currently Enabled (Disable)
 			region.disabled = true;
 			//Set Region value to 0, save current val for when enabled again.
 			region.value = 0;
-
-			//Set to disabled attributes & style
-			region.nodes.region.style.fillOpacity = '0.25';
-			region.nodes.region.style.strokeOpacity = '0.25';
-
-			//Button
-			const button = region.nodes.button;
-			if (button) {
-				button.style.fillOpacity = '0.25';
-				button.style.strokeOpacity = '0.25';
-			}
 		}
 		RegionsStore.set(regions);
 	}
@@ -104,7 +82,7 @@ function loadRegions(node: HTMLDivElement): void {
 			id: childHTML.getAttribute('class') ?? '',
 			shortName: childHTML.getAttribute('short-name') ?? '',
 			longName: childHTML.getAttribute('long-name') ?? '',
-			value,
+			value: childHTML.hasAttribute('disabled') ? 0 : value,
 			permaVal: value,
 			disabled: childHTML.hasAttribute('disabled'),
 			candidates: [{ candidate: tossupCandidate, count: value, margin: 0 }],


### PR DESCRIPTION
When reintroducing disabled states the other day, I overlooked the need for certain region vars/style attributes to be different depending on whether or not the state was defined as disabled in the map SVG itself. This PR remedies this.

Summary of Code Changes:
- Moves application of disabled styles to the function that handles the rest of region styles rather than setting them directly in the function that disables the state.
- Changes the value parameter on state initialization to be set to 0 if state defined as disabled in SVG. No data is lost due to permaVal being set to value.

Disabled attribute on the SVG element can be set to anything, as long as it has the attribute, it is considered disabled.
Closes #54.