### PR TITLE
Locked States

### DIFF
--- a/client/src/lib/components/navbar/NavBar.svelte
+++ b/client/src/lib/components/navbar/NavBar.svelte
@@ -72,6 +72,9 @@
 			<!-- svelte-ignore a11y-missing-attribute -->
 			<!-- svelte-ignore a11y-click-events-have-key-events -->
 			<li><a on:click={() => setMode('disable')}>Disable</a></li>
+			<!-- svelte-ignore a11y-missing-attribute -->
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
+			<li><a on:click={() => setMode('lock')}>Lock</a></li>
 		</ul>
 	</div>
 	<div class="dropdown">

--- a/client/src/lib/stores/Regions.ts
+++ b/client/src/lib/stores/Regions.ts
@@ -48,18 +48,18 @@ RegionsStore.subscribe((regions) => {
 		}
 
 		region.nodes.region.style.fill = winner.candidate.margins[marginIndex]?.color;
-		region.disabled
+		region.disabled || region.locked
 			? (region.nodes.region.style.fillOpacity = '0.25')
 			: (region.nodes.region.style.fillOpacity = '1'); //Transparent if disabled
-		region.disabled
+		region.disabled || region.locked
 			? (region.nodes.region.style.strokeOpacity = '0.25')
 			: (region.nodes.region.style.strokeOpacity = '1'); //Transparent if disabled
 		if (region.nodes.button) {
 			region.nodes.button.style.fill = winner.candidate.margins[marginIndex]?.color;
-			region.disabled
+			region.disabled || region.locked
 				? (region.nodes.button.style.fillOpacity = '0.25')
 				: (region.nodes.button.style.fillOpacity = '1'); //Transparent if disabled
-			region.disabled
+			region.disabled || region.locked
 				? (region.nodes.button.style.strokeOpacity = '0.25')
 				: (region.nodes.button.style.strokeOpacity = '1'); //Transparent if disabled
 		}

--- a/client/src/lib/types/Mode.ts
+++ b/client/src/lib/types/Mode.ts
@@ -1,1 +1,1 @@
-export type Mode = 'fill' | 'edit' | 'disable';
+export type Mode = 'fill' | 'edit' | 'disable' | 'lock';

--- a/client/src/lib/types/Region.ts
+++ b/client/src/lib/types/Region.ts
@@ -7,6 +7,7 @@ type Region = {
 	value: number;
 	permaVal: number;
 	disabled: boolean;
+	locked: boolean;
 	candidates: Array<{ candidate: Candidate; count: number; margin: number }>;
 	nodes: {
 		region: HTMLElement;


### PR DESCRIPTION
Adds in "Locked States" which are just resistant to filling. Using same styles as disabled for now, can distinguish by the fact that they still use candidate colors and have non-zero values. Probably a good idea to change styles in the future.
![image](https://user-images.githubusercontent.com/42476312/209029229-e5bfcce8-dd3e-4e5a-a450-e34bf15c5a63.png)
Locked ND & SD, Disabled MN.

Summary of Code Changes
- Adds new "Locked" property to regions, set to true if region has "locked" attribute in SVG.
- Adds 'lock' as a valid mode type.
- Disables fill if region has locked property
- Adds incredibly simple lock function, I don't think I can simply it further due to the way the region store is set up.

Closes #53.