### PR TITLE
Fixes to map loading

### DIFF
--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
@@ -1,11 +1,11 @@
 import panzoom, { type PanZoom } from 'panzoom';
 
 function applyPanZoom(mapBind: HTMLDivElement): PanZoom | undefined {
-	const svg = mapBind.querySelector<SVGElement>('#testing-map');
+	const svg = mapBind.querySelector<SVGElement>('svg'); //We can do this since the only child of node is the map svg itself.
 	if (svg) {
 		return panzoom(svg, {
 			minZoom: 0.5,
-			maxZoom: 2,
+			maxZoom: 100,
 			smoothScroll: false,
 			autocenter: true,
 			zoomDoubleClickSpeed: 1

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
@@ -104,8 +104,8 @@ function loadRegions(node: HTMLDivElement): void {
 
 	// set cursor & pointer styles
 	(regions as HTMLElement).style.cursor = 'pointer';
-	(buttons as HTMLElement).style.cursor = 'pointer';
-	(texts as HTMLElement).style.pointerEvents = 'none';
+	if (buttons) (buttons as HTMLElement).style.cursor = 'pointer';
+	if (texts) (texts as HTMLElement).style.pointerEvents = 'none';
 
 	regions?.childNodes.forEach((childNode) => {
 		const childHTML = childNode as HTMLElement;


### PR DESCRIPTION
Fixes two issues related to loading maps, one where the map won't load if no text or buttons are defined, and one where panZoom won't properly apply to maps without id #testing-map.

Summary of Code Changes:
- Changes applyPanZoom to not look for a map specifically called #testing-map and instead look for an svg element in general.
- Changes panZoom max zoom to 100 from 2, will be useful for more detailed maps like the US house.
- Adds two conditionals to check if there are any buttons or texts before running code that requires them.

Closes #66 and #67 