### PR TITLE
Mobile compatibility

### DIFF
--- a/apps/yapms/src/lib/components/modals/addcandidatemodal/AddCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/addcandidatemodal/AddCandidateModal.svelte
@@ -26,6 +26,10 @@
 	}
 
 	function selectPresetColor() {
+		AddCandidateModalStore.set({
+			...$AddCandidateModalStore,
+			open: false
+		})
 		PresetColorsModalStore.set({
 			open: true
 		});
@@ -47,7 +51,7 @@
 </script>
 
 <input type="checkbox" class="modal-toggle" checked={$AddCandidateModalStore.open} />
-<div class="modal">
+<div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
 		<h2 class="text-2xl">Add Candidate</h2>
 

--- a/apps/yapms/src/lib/components/modals/charttypemodal/ChartTypeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/charttypemodal/ChartTypeModal.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { ChartTypeStore } from '$lib/stores/Chart';
+	import { ChartTypeModalStore } from '$lib/stores/Modals';
+	import type { ChartType } from '$lib/types/ChartType';
+
+	const types = ['pie','battle'];
+
+	function close() {
+		ChartTypeModalStore.set({
+			...$ChartTypeModalStore,
+			open: false
+		});
+	}
+
+	function setChartType(id: string) {
+		ChartTypeStore.set(id as ChartType)
+	}
+</script>
+
+<input type="checkbox" class="modal-toggle" checked={$ChartTypeModalStore.open} />
+<div class="modal modal-bottom lg:modal-middle">
+	<div class="modal-box">
+		<h2 class="text-2xl">Change Chart Type</h2>
+		<br>
+		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly">
+			{#each types as type}
+				<button
+					class="btn gap-1 w-2/3 lg:w-1/2"
+					class:btn-primary={$ChartTypeStore !== type}
+					class:btn-success={$ChartTypeStore === type}
+					on:click={() => {
+						setChartType(type);
+						close();
+					}}
+				>
+					<span>
+						{type.toUpperCase()}
+					</span>
+				</button>
+			{/each}
+		</div>
+		<div class="modal-action">
+			<button class="btn btn-primary" on:click={close}>Close</button>
+		</div>
+	</div>
+</div>

--- a/apps/yapms/src/lib/components/modals/clearmapmodal/ClearMapModal.svelte
+++ b/apps/yapms/src/lib/components/modals/clearmapmodal/ClearMapModal.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <input type="checkbox" class="modal-toggle" checked={$ClearMapModalStore.open} />
-<div class="modal">
+<div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
 		<h3 class="font-bold text-lg">Clear The Map?</h3>
 		<p>Clearing the map will result in all your progress being cleared.</p>

--- a/apps/yapms/src/lib/components/modals/editcandidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/editcandidatemodal/EditCandidateModal.svelte
@@ -56,7 +56,7 @@
 </script>
 
 <input type="checkbox" class="modal-toggle" checked={open} />
-<div class="modal">
+<div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
 		<h3 class="font-bold text-lg">{name}</h3>
 		<div class="flex gap-3">

--- a/apps/yapms/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
+++ b/apps/yapms/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
@@ -26,7 +26,7 @@
 
 <input type="checkbox" class="modal-toggle" checked={open} />
 
-<div class="modal">
+<div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
 		<h3 class="font-bold text-lg">Edit State {longName} {value}</h3>
 		<div class="flex flex-col pt-3">

--- a/apps/yapms/src/lib/components/modals/mapmodal/MapModal.svelte
+++ b/apps/yapms/src/lib/components/modals/mapmodal/MapModal.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <input type="checkbox" class="modal-toggle" checked={$MapModalStore.open} />
-<div class="modal">
+<div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
 		<div class="tabs justify-evenly">
 			{#each countries as country}

--- a/apps/yapms/src/lib/components/modals/modemodal/ModeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/modemodal/ModeModal.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { ModeModalStore } from '$lib/stores/Modals';
+	import { ModeStore } from '$lib/stores/Mode';
+	import type { Mode } from '$lib/types/Mode';
+
+	const modes = ['fill','edit','disable','lock'];
+
+	function close() {
+		ModeModalStore.set({
+			...$ModeModalStore,
+			open: false
+		});
+	}
+
+	function setMode(id: string) {
+		ModeStore.set(id as Mode)
+	}
+</script>
+
+<input type="checkbox" class="modal-toggle" checked={$ModeModalStore.open} />
+<div class="modal modal-bottom lg:modal-middle">
+	<div class="modal-box">
+		<h2 class="text-2xl">Change Mode</h2>
+		<br>
+		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly">
+			{#each modes as mode}
+				<button
+					class="btn gap-1 w-2/3 lg:w-1/2"
+					class:btn-primary={$ModeStore !== mode}
+					class:btn-success={$ModeStore === mode}
+					on:click={() => {
+						setMode(mode);
+						close();
+					}}
+				>
+					<span>
+						{mode.toUpperCase()}
+					</span>
+				</button>
+			{/each}
+		</div>
+		<div class="modal-action">
+			<button class="btn btn-primary" on:click={close}>Close</button>
+		</div>
+	</div>
+</div>

--- a/apps/yapms/src/lib/components/modals/presetcolorsmodal/PresetColorsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/presetcolorsmodal/PresetColorsModal.svelte
@@ -65,11 +65,16 @@
 		PresetColorsModalStore.set({
 			open: false
 		});
+		AddCandidateModalStore.set({
+			...$AddCandidateModalStore,
+			open: true
+		});
 	}
 
 	function confirm(margins: string[]) {
 		AddCandidateModalStore.set({
-			open: true,
+			...$AddCandidateModalStore,
+			open:true,
 			newColors: margins
 		});
 		PresetColorsModalStore.set({
@@ -79,7 +84,7 @@
 </script>
 
 <input type="checkbox" class="modal-toggle" checked={$PresetColorsModalStore.open} />
-<div class="modal modal-bottom">
+<div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
 		<div class="flex flex-row gap-2 pb-5 justify-between">
 			<h2 class="text-2xl">Preset Colors</h2>

--- a/apps/yapms/src/lib/components/modals/thememodal/ThemeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/thememodal/ThemeModal.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { ThemeModalStore } from '$lib/stores/Modals';
+
+	function close() {
+		ThemeModalStore.set({
+			...$ThemeModalStore,
+			open: false
+		});
+	}
+
+	const themes = [ //Hex codes can be found in node_modules/daisyui/src/colors/themes
+	//name: id for theme, margins ['base-100','primary','secondary','accent']
+		{ name: 'light', margins: ['#ffffff', '#570df8', '#f000b8', '#37cdbe'] },
+		{ name: 'dark', margins: ['#2A303C', '#661AE6', '#D926AA', '#1FB2A5'] },
+		{ name: 'cupcake', margins: ['#faf7f5', '#65c3c8', '#ef9fbc', '#eeaf3a'] },
+		{ name: 'aqua', margins: ['#345da7', '#09ecf3', '#966fb3', '#ffe999'] },
+		{ name: 'lofi', margins: ['#ffffff', '#0D0D0D', '#1A1919', '#262626'] },
+		{ name: 'night', margins: ['#0F172A', '#38bdf8', '#818CF8', '#F471B5'] }
+	];
+</script>
+
+<input type="checkbox" class="modal-toggle" checked={$ThemeModalStore.open} />
+<div class="modal modal-bottom lg:modal-middle">
+	<div class="modal-box">
+		<h2 class="text-2xl">Change Theme</h2>
+		<br>
+		<div class="flex flex-row gap-3 flex-wrap justify-center">
+			{#each themes as theme}
+				<button class="btn btn-lg" data-set-theme={theme.name} data-act-class="ACTIVECLASS">
+					<div class="flex flex-col gap-2">
+						<h3>{theme.name}</h3>
+						<div class="flex flex-row gap-2">
+							{#each theme.margins as margin}
+								<div
+									class="outline outline-1 outline-white w-4 h-4 rounded-full"
+									style:background-color={margin}
+								/>
+							{/each}
+						</div>
+					</div>
+				</button>
+			{/each}
+		</div>
+		<div class="modal-action">
+			<button class="btn btn-primary" on:click={close}>Close</button>
+		</div>
+	</div>
+</div>

--- a/apps/yapms/src/lib/components/navbar/NavBar.svelte
+++ b/apps/yapms/src/lib/components/navbar/NavBar.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	import { ChartPositionStore, ChartTypeStore } from '$lib/stores/Chart';
-	import { ClearMapModalStore, MapModalStore, AddCandidateModalStore } from '$lib/stores/Modals';
+	import { ChartPositionStore } from '$lib/stores/Chart';
+	import { ClearMapModalStore, MapModalStore, AddCandidateModalStore, ModeModalStore, ChartTypeModalStore, ThemeModalStore } from '$lib/stores/Modals';
 	import { ModeStore } from '$lib/stores/Mode';
-	import type { ChartType } from '$lib/types/ChartType';
-	import type { Mode } from '$lib/types/Mode';
 
 	function openClearMapModal() {
 		ClearMapModalStore.set({
@@ -26,12 +24,25 @@
 		});
 	}
 
-	function setMode(mode: Mode) {
-		ModeStore.set(mode);
+	function openChartType() {
+		ChartTypeModalStore.set({
+			...$ChartTypeModalStore,
+			open: true
+		});
 	}
 
-	function setChartType(chartType: ChartType) {
-		ChartTypeStore.set(chartType);
+	function openMode() {
+		ModeModalStore.set({
+			...$ModeModalStore,
+			open: true
+		});
+	}
+
+	function openTheme() {
+		ThemeModalStore.set({
+			...$ThemeModalStore,
+			open: true
+		});
 	}
 
 	function toggleChartPosition() {
@@ -41,64 +52,13 @@
 	}
 </script>
 
-<div class="navbar bg-base-200 gap-3">
+<div class="navbar bg-base-200 gap-3 overflow-x-scroll overflow-y-clip lg:overflow-x-clip">
 	<button class="btn btn-sm">home</button>
 	<button class="btn btn-sm" on:click={openClearMapModal}>clear</button>
 	<button class="btn btn-sm" on:click={openMapModal}>maps</button>
 	<button class="btn btn-sm" on:click={openAddCandidateModal}>add candidate</button>
 	<button class="btn btn-sm" on:click={toggleChartPosition}>chart position</button>
-	<div class="dropdown">
-		<!-- svelte-ignore a11y-label-has-associated-control -->
-		<label tabindex="-1" class="btn btn-sm">chart type</label>
-		<ul tabindex="-1" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 mt-4">
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a on:click={() => setChartType('battle')}>Battle</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a on:click={() => setChartType('pie')}>Pie</a></li>
-		</ul>
-	</div>
-	<div class="dropdown">
-		<!-- svelte-ignore a11y-label-has-associated-control -->
-		<label tabindex="-1" class="btn btn-sm">mode: {$ModeStore}</label>
-		<ul tabindex="-1" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 mt-4">
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a on:click={() => setMode('fill')}>Fill</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a on:click={() => setMode('edit')}>Edit</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a on:click={() => setMode('disable')}>Disable</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a on:click={() => setMode('lock')}>Lock</a></li>
-		</ul>
-	</div>
-	<div class="dropdown">
-		<!-- svelte-ignore a11y-label-has-associated-control -->
-		<label tabindex="-1" class="btn btn-sm">theme</label>
-		<ul tabindex="-1" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 mt-4">
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a data-set-theme="light" data-act-class="ACTIVECLASS">Light</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a data-set-theme="dark" data-act-class="ACTIVECLASS">Dark</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a data-set-theme="cupcake" data-act-class="ACTIVECLASS">Cupcake</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a data-set-theme="aqua" data-act-class="ACTIVECLASS">Aqua</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a data-set-theme="lofi" data-act-class="ACTIVECLASS">Lofi</a></li>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<li><a data-set-theme="night" data-act-class="ACTIVECLASS">Night</a></li>
-		</ul>
-	</div>
+	<button class="btn btn-sm" on:click={openChartType}>chart type</button>
+	<button class="btn btn-sm" on:click={openMode}>mode: {$ModeStore}</button>
+	<button class="btn btn-sm" on:click={openTheme}>theme</button>
 </div>

--- a/apps/yapms/src/lib/components/sidebar/SideBar.svelte
+++ b/apps/yapms/src/lib/components/sidebar/SideBar.svelte
@@ -25,7 +25,7 @@
 	$: title = titles.find((elem) => elem.path === $page.url.pathname)?.title ?? 'YAPms';
 </script>
 
-<div class="divider divider-horizontal ml-0 w-0" />
+<div class="divider md:divider-horizontal ml-0 w-0" />
 <div class="basis-3/12 hidden md:inline" transition:slideX={{ duration: 300 }}>
 	<div class="flex flex-wrap justify-center gap-2 p-2">
 		<button type="button" class="btn btn-sm gap-2">

--- a/apps/yapms/src/lib/stores/Modals.ts
+++ b/apps/yapms/src/lib/stores/Modals.ts
@@ -36,11 +36,26 @@ const PresetColorsModalStore = writable({
 	open: false
 });
 
+const ChartTypeModalStore = writable({
+	open: false
+});
+
+const ModeModalStore = writable({
+	open: false
+});
+
+const ThemeModalStore = writable({
+	open: false
+});
+
 export {
 	EditCandidateModalStore,
 	ClearMapModalStore,
 	MapModalStore,
 	EditRegionModalStore,
 	AddCandidateModalStore,
-	PresetColorsModalStore
+	PresetColorsModalStore,
+	ChartTypeModalStore,
+	ModeModalStore,
+	ThemeModalStore
 };

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -10,6 +10,7 @@
 	import ClearMapModal from '$lib/components/modals/clearmapmodal/ClearMapModal.svelte';
 	import applyPanZoom from './initialize/ApplyPanZoom';
 	import EditRegionModal from '$lib/components/modals/editregionmodal/EditRegionModal.svelte';
+	import ModeModal from '$lib/components/modals/modemodal/ModeModal.svelte';
 	import { InteractionStore } from '$lib/stores/Interaction';
 	import { ChartPositionStore, ChartTypeStore } from '$lib/stores/Chart';
 	import { CandidatesStore } from '$lib/stores/Candidates';
@@ -17,6 +18,8 @@
 	import HorizontalBattleChart from '$lib/components/chartbar/battlechart/BattleChart.svelte';
 	import ChartBar from '$lib/components/chartbar/ChartBar.svelte';
 	import PresetColorsModal from '$lib/components/modals/presetcolorsmodal/PresetColorsModal.svelte';
+	import ChartTypeModal from '$lib/components/modals/charttypemodal/ChartTypeModal.svelte';
+	import ThemeModal from '$lib/components/modals/thememodal/ThemeModal.svelte';
 
 	const imports = {
 		usa: () => import('$lib/assets/usa.svg?raw'),
@@ -104,3 +107,9 @@
 <EditRegionModal />
 
 <MapModal />
+
+<ChartTypeModal />
+
+<ModeModal />
+
+<ThemeModal />

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
@@ -143,7 +143,7 @@ function loadRegions(node: HTMLDivElement): void {
 			}
 		};
 
-		newRegion.nodes.region.onclick = () => {
+		newRegion.nodes.region.onpointerdown = () => {
 			const currentMode = get(ModeStore);
 			switch (currentMode) {
 				case 'fill':
@@ -171,7 +171,7 @@ function loadRegions(node: HTMLDivElement): void {
 		};
 
 		if (newRegion.nodes.button !== null) {
-			newRegion.nodes.button.onclick = newRegion.nodes.region.onclick;
+			newRegion.nodes.button.onpointerdown = newRegion.nodes.region.onpointerdown;
 			newRegion.nodes.button.onmousemove = newRegion.nodes.region.onmousemove;
 		}
 


### PR DESCRIPTION
Adds mobile compatibility to yapms. To do this, the following changes had to be made:
- NavBar made scrollable
- All dropdowns in the NavBar changed to modals (overflow-y cannot be visible when overflow-x is scroll)
![image](https://user-images.githubusercontent.com/42476312/209576987-df7a434b-7714-48dc-b4a5-70d0efad779c.png)
_Example of dropdown modal replacement_
![image](https://user-images.githubusercontent.com/42476312/209577049-ab3059dd-ddc6-4250-9f69-0847429106cd.png)
_Theme modal specific design_

Code Changes:
- ChartTypeModal, ModeModal, and ThemeModal added, corresponding stores added as well.
- All existing modals had classes changed to appear on the bottom for small and medium devices, kept in the middle for large devices.
- NavBar had styles updated to make it scrollable (added overflow-x-scroll & overflow-y-clip)
- SideBar divider made invisible on small devices via changing "divider-horizontal" to "md:divider-horizontal"
- Map clicking event changed from "click" to "onpointerdown". Keeps same functionality on desktop and fixes the map for mobile.

Closes #72, #73, #74.