### PR TITLE
Standardize Modal Style

### DIFF
--- a/apps/yapms/src/lib/components/modals/ModalTitle.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalTitle.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  export let title: string;
+</script>
+
+<h3 class="text-2xl pb-3">
+  {title}
+</h3>

--- a/apps/yapms/src/lib/components/modals/addcandidatemodal/AddCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/addcandidatemodal/AddCandidateModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { CandidatesStore } from '$lib/stores/Candidates';
 	import { AddCandidateModalStore, PresetColorsModalStore } from '$lib/stores/Modals';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	let newName = '';
 
@@ -53,9 +54,9 @@
 <input type="checkbox" class="modal-toggle" checked={$AddCandidateModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h2 class="text-2xl">Add Candidate</h2>
+		<ModalTitle title="Add Candidate" />
 
-		<div class="flex pt-2">
+		<div class="flex">
 			<div class="form-control w-full max-w-xs flex flex-col gap-3">
 				<h3 class="font-light text-lg">Name</h3>
 				<input type="text" class="input input-bordered w-full max-w-xs" bind:value={newName} />
@@ -101,8 +102,8 @@
 		</div>
 
 		<div class="modal-action">
-			<button class="btn btn-primary" on:click={close}> Close </button>
-			<button class="btn btn-primary" on:click={confirm}> Confirm </button>
+			<button class="btn btn-primary" on:click={close}> No </button>
+			<button class="btn btn-success" on:click={confirm}> Add </button>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/charttypemodal/ChartTypeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/charttypemodal/ChartTypeModal.svelte
@@ -2,6 +2,7 @@
 	import { ChartTypeStore } from '$lib/stores/Chart';
 	import { ChartTypeModalStore } from '$lib/stores/Modals';
 	import type { ChartType } from '$lib/types/ChartType';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	const types = ['pie','battle'];
 
@@ -20,8 +21,7 @@
 <input type="checkbox" class="modal-toggle" checked={$ChartTypeModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h2 class="text-2xl">Change Chart Type</h2>
-		<br>
+		<ModalTitle title="Change Chart Type" />
 		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly">
 			{#each types as type}
 				<button
@@ -40,7 +40,7 @@
 			{/each}
 		</div>
 		<div class="modal-action">
-			<button class="btn btn-primary" on:click={close}>Close</button>
+			<button class="btn btn-primary" on:click={close}>No</button>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/clearmapmodal/ClearMapModal.svelte
+++ b/apps/yapms/src/lib/components/modals/clearmapmodal/ClearMapModal.svelte
@@ -3,6 +3,7 @@
 	import { ClearMapModalStore } from '$lib/stores/Modals';
 	import { RegionsStore } from '$lib/stores/Regions';
 	import { get } from 'svelte/store';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	function clearMap() {
 		const regions = get(RegionsStore);
@@ -37,12 +38,11 @@
 <input type="checkbox" class="modal-toggle" checked={$ClearMapModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h3 class="font-bold text-lg">Clear The Map?</h3>
-		<p>Clearing the map will result in all your progress being cleared.</p>
-		<p>Are you sure?</p>
+		<ModalTitle title="Clear Map" />
+		<p>Clearing the map will result in all your progress being cleared. Are you sure?</p>
 		<div class="modal-action">
-			<button class="btn" on:click={close}> Close </button>
-			<button class="btn" on:click={confirm}> Confirm </button>
+			<button class="btn btn-primary" on:click={close}> No </button>
+			<button class="btn btn-error" on:click={confirm}> Clear </button>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/editcandidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/editcandidatemodal/EditCandidateModal.svelte
@@ -3,6 +3,7 @@
 	import { RegionsStore } from '$lib/stores/Regions';
 	import { EditCandidateModalStore } from '$lib/stores/Modals';
 	import { get } from 'svelte/store';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	$: open = $EditCandidateModalStore.open;
 	$: id = open ? $EditCandidateModalStore.candidate.id : '';
@@ -78,8 +79,8 @@
 <input type="checkbox" class="modal-toggle" checked={open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h3 class="text-2xl">{name}</h3>
-		<div class="flex pt-2 gap-1">
+		<ModalTitle title="Edit {name}" />
+		<div class="flex gap-1">
 			<div class="form-control w-full max-w-xs flex flex-col gap-3">
 				<h3 class="font-light text-lg">Name</h3>
 				<input type="text" class="input input-bordered w-full max-w-xs" bind:value={newName} />
@@ -108,7 +109,7 @@
 					/>
 					<input
 						type="button"
-						class="btn btn-primary btn-sm grow"
+						class="btn btn-success btn-sm grow"
 						on:click={addColor}
 						value="Add"
 					/>
@@ -117,9 +118,9 @@
 		</div>
 		<div class="modal-action">
 			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<label for="my-modal" class="btn btn-primary" on:click={cancel}>Cancel</label>
+			<label for="my-modal" class="btn btn-primary" on:click={cancel}>No</label>
 			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<label for="my-modal" class="btn btn-primary" on:click={confirm}>Confirm</label>
+			<label for="my-modal" class="btn btn-success" on:click={confirm}>Update</label>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
+++ b/apps/yapms/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { EditRegionModalStore } from '$lib/stores/Modals';
 	import { RegionsStore } from '$lib/stores/Regions';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	$: open = $EditRegionModalStore.open;
 	$: longName = open ? $EditRegionModalStore.region?.longName : undefined;
@@ -28,19 +29,17 @@
 
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h3 class="font-bold text-lg">Edit State {longName} {value}</h3>
-		<div class="flex flex-col pt-3">
-			<input
-				type="number"
-				placeholder="Value"
-				class="input input-bordered w-full"
-				min="1"
-				bind:value={newValue}
-			/>
-		</div>
+		<ModalTitle title="Edit Region {longName} - {value}" />
+		<input
+			type="number"
+			placeholder="Value"
+			class="input input-bordered w-full"
+			min="1"
+			bind:value={newValue}
+		/>
 		<div class="modal-action">
-			<button class="btn" on:click={close}> Close </button>
-			<button class="btn" on:click={confirm}> Confirm </button>
+			<button class="btn btn-primary" on:click={close}> No </button>
+			<button class="btn btn-success" on:click={confirm}> Update </button>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/mapmodal/MapModal.svelte
+++ b/apps/yapms/src/lib/components/modals/mapmodal/MapModal.svelte
@@ -5,6 +5,7 @@
 	import can_flag from '$lib/assets/flags/can.svg';
 	import gbr_flag from '$lib/assets/flags/gbr.svg';
 	import aus_flag from '$lib/assets/flags/aus.svg';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	let selectedCountryName = 'usa';
 
@@ -29,6 +30,7 @@
 <input type="checkbox" class="modal-toggle" checked={$MapModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
+		<ModalTitle title="Change Map" />
 		<div class="tabs justify-evenly">
 			{#each countries as country}
 				<button
@@ -38,7 +40,7 @@
 						selectedCountryName = country.name;
 					}}
 				>
-					<img src={country.flag} alt="flag" class="w-12 rounded-sm" />
+					<img src={country.flag} alt="flag" class="w-10 rounded-sm" />
 					<span>
 						{country.name.toUpperCase()}
 					</span>
@@ -55,7 +57,7 @@
 			</div>
 		</div>
 		<div class="modal-action">
-			<button class="btn btn-primary" on:click={close}>Close</button>
+			<button class="btn btn-primary" on:click={close}>No</button>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/modemodal/ModeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/modemodal/ModeModal.svelte
@@ -2,6 +2,7 @@
 	import { ModeModalStore } from '$lib/stores/Modals';
 	import { ModeStore } from '$lib/stores/Mode';
 	import type { Mode } from '$lib/types/Mode';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	const modes = ['fill','edit','disable','lock'];
 
@@ -20,8 +21,7 @@
 <input type="checkbox" class="modal-toggle" checked={$ModeModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h2 class="text-2xl">Change Mode</h2>
-		<br>
+		<ModalTitle title="Change Mode" />
 		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly">
 			{#each modes as mode}
 				<button
@@ -40,7 +40,7 @@
 			{/each}
 		</div>
 		<div class="modal-action">
-			<button class="btn btn-primary" on:click={close}>Close</button>
+			<button class="btn btn-primary" on:click={close}>No</button>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/presetcolorsmodal/PresetColorsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/presetcolorsmodal/PresetColorsModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { AddCandidateModalStore, PresetColorsModalStore } from '$lib/stores/Modals';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	let tab = 0;
 
@@ -86,20 +87,17 @@
 <input type="checkbox" class="modal-toggle" checked={$PresetColorsModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<div class="flex flex-row gap-2 pb-5 justify-between">
-			<h2 class="text-2xl">Preset Colors</h2>
-			<div class="tabs">
-				{#each groups as group, index}
-					<button
-						class="tab tab-bordered tab-lg"
-						class:tab-active={index === tab}
-						on:click={() => setTab(index)}
-					>
-						{group.name}
-					</button>
-				{/each}
-			</div>
-			<input type="button" class="btn btn-error" value="Close" on:click={close} />
+		<ModalTitle title="Select Preset Colors" />
+		<div class="tabs pb-4 justify-center">
+			{#each groups as group, index}
+				<button
+					class="tab tab-bordered tab-lg"
+					class:tab-active={index === tab}
+					on:click={() => setTab(index)}
+				>
+					{group.name}
+				</button>
+			{/each}
 		</div>
 
 		<div class="flex flex-row gap-3 flex-wrap justify-center">
@@ -118,6 +116,9 @@
 					</div>
 				</button>
 			{/each}
+		</div>
+		<div class="modal-action">
+			<input type="button" class="btn btn-primary" value="No" on:click={close} />
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/thememodal/ThemeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/thememodal/ThemeModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { ThemeModalStore } from '$lib/stores/Modals';
+	import ModalTitle from '../ModalTitle.svelte';
 
 	function close() {
 		ThemeModalStore.set({
@@ -22,8 +23,7 @@
 <input type="checkbox" class="modal-toggle" checked={$ThemeModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h2 class="text-2xl">Change Theme</h2>
-		<br>
+		<ModalTitle title="Change Theme" />
 		<div class="flex flex-row gap-3 flex-wrap justify-center">
 			{#each themes as theme}
 				<button class="btn btn-lg" data-set-theme={theme.name} data-act-class="ACTIVECLASS">
@@ -42,7 +42,7 @@
 			{/each}
 		</div>
 		<div class="modal-action">
-			<button class="btn btn-primary" on:click={close}>Close</button>
+			<button class="btn btn-primary" on:click={close}>No</button>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Feature: Standardized the styling of the modal title. Also changed the wording of the actions on a modal.

The title should be a request, and the action buttons should be a response.

Example: Clear Map is the request, and the user can say no, or clear.
![image](https://user-images.githubusercontent.com/13600696/209588983-35a9c74e-f22b-471e-9f8f-05059642206a.png)

Code:
1) Added a ModalTitle. This will standardize the font and padding.
2) Updated wordings on buttons and titles.

closes #78 