### PR TITLE
Remove sidebar whitespace

### DIFF
--- a/apps/yapms/src/lib/components/sidebar/SideBar.svelte
+++ b/apps/yapms/src/lib/components/sidebar/SideBar.svelte
@@ -25,7 +25,8 @@
 	$: title = titles.find((elem) => elem.path === $page.url.pathname)?.title ?? 'YAPms';
 </script>
 
-<div class="divider md:divider-horizontal ml-0 w-0" />
+<div class="divider divider-horizontal w-0 m-0 hidden md:flex" />
+
 <div class="basis-3/12 hidden md:inline" transition:slideX={{ duration: 300 }}>
 	<div class="flex flex-wrap justify-center gap-2 p-2">
 		<button type="button" class="btn btn-sm gap-2">


### PR DESCRIPTION
Preview:

![image](https://user-images.githubusercontent.com/13600696/211177686-deba3425-6238-49cc-aabe-af69f2349f87.png)


Code:

Use the "display:none" and "display:flex" properties, because the divider-horizontal would take priority over the width and margin if it had media queries.

closes #92 