### PR TITLE
replace theme modal with style modal

### DIFF
--- a/apps/yapms/src/lib/components/modals/stylemodal/StyleModal.svelte
+++ b/apps/yapms/src/lib/components/modals/stylemodal/StyleModal.svelte
@@ -61,13 +61,15 @@
 		<div class="flex flex-col">
 		<h3 class="font-light text-lg pb-3">Chart Position</h3>
 		<div class="flex gap-3 justify-center">
-			<button class="btn btn-secondary btn-lg"
-				class:btn-outline={$ChartPositionStore === 'bottom'}
+			<button class="btn btn-lg"
+				class:btn-primary={$ChartPositionStore === 'bottom'}
+				class:btn-success={$ChartPositionStore === 'left'}
 				on:click={sideChart}>
 				Side
 			</button>
-			<button class="btn btn-secondary btn-lg"
-				class:btn-outline={$ChartPositionStore === 'left'}
+			<button class="btn btn-lg"
+				class:btn-primary={$ChartPositionStore === 'left'}
+				class:btn-success={$ChartPositionStore === 'bottom'}
 				on:click={bottomChart}>
 				Bottom
 			</button>

--- a/apps/yapms/src/lib/components/modals/stylemodal/StyleModal.svelte
+++ b/apps/yapms/src/lib/components/modals/stylemodal/StyleModal.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import { ThemeModalStore } from '$lib/stores/Modals';
+	import { ChartPositionStore } from '$lib/stores/Chart';
+	import { StyleModalStore } from '$lib/stores/Modals';
 	import ModalTitle from '../../modalutilities/ModalTitle.svelte';
 
 	function close() {
-		ThemeModalStore.set({
-			...$ThemeModalStore,
+		StyleModalStore.set({
+			...$StyleModalStore,
 			open: false
 		});
 	}
@@ -18,12 +19,24 @@
 		{ name: 'lofi', margins: ['#ffffff', '#0D0D0D', '#1A1919', '#262626'] },
 		{ name: 'night', margins: ['#0F172A', '#38bdf8', '#818CF8', '#F471B5'] }
 	];
+
+	function sideChart() {
+		ChartPositionStore.set("left");
+	}
+
+	function bottomChart() {
+		ChartPositionStore.set("bottom");
+	}
 </script>
 
-<input type="checkbox" class="modal-toggle" checked={$ThemeModalStore.open} />
+<input type="checkbox" class="modal-toggle" checked={$StyleModalStore.open} />
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<ModalTitle title="Change Theme" />
+		<ModalTitle title="Change Style" />
+		<div class="flex flex-row lg:flex-col">
+
+		<div class="flex flex-col">
+		<h3 class="font-light text-lg pb-3">Themes</h3>
 		<div class="flex flex-row gap-3 flex-wrap justify-center">
 			{#each themes as theme}
 				<button class="btn btn-lg" data-set-theme={theme.name} data-act-class="ACTIVECLASS">
@@ -41,8 +54,28 @@
 				</button>
 			{/each}
 		</div>
-		<div class="modal-action">
-			<button class="btn btn-primary" on:click={close}>No</button>
+		</div>
+
+		<div class="divider divider-horizontal lg:divider-vertical"></div>
+
+		<div class="flex flex-col">
+		<h3 class="font-light text-lg pb-3">Chart Position</h3>
+		<div class="flex gap-3 justify-center">
+			<button class="btn btn-secondary btn-lg"
+				class:btn-outline={$ChartPositionStore === 'bottom'}
+				on:click={sideChart}>
+				Side
+			</button>
+			<button class="btn btn-secondary btn-lg"
+				class:btn-outline={$ChartPositionStore === 'left'}
+				on:click={bottomChart}>
+				Bottom
+			</button>
+		</div>
 		</div>
 	</div>
+	<div class="modal-action">
+		<button class="btn btn-primary" on:click={close}>No</button>
+	</div>
+</div>
 </div>

--- a/apps/yapms/src/lib/components/navbar/NavBar.svelte
+++ b/apps/yapms/src/lib/components/navbar/NavBar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { ChartPositionStore } from '$lib/stores/Chart';
-	import { ClearMapModalStore, MapModalStore, AddCandidateModalStore, ModeModalStore, ChartTypeModalStore, ThemeModalStore, LoginModalStore } from '$lib/stores/Modals';
+	import { ClearMapModalStore, MapModalStore, AddCandidateModalStore, ModeModalStore, ChartTypeModalStore, StyleModalStore, LoginModalStore } from '$lib/stores/Modals';
 	import { ModeStore } from '$lib/stores/Mode';
 
 	function openClearMapModal() {
@@ -38,16 +37,10 @@
 		});
 	}
 
-	function openTheme() {
-		ThemeModalStore.set({
-			...$ThemeModalStore,
+	function openStyle() {
+		StyleModalStore.set({
+			...$StyleModalStore,
 			open: true
-		});
-	}
-
-	function toggleChartPosition() {
-		ChartPositionStore.update((chartPosition) => {
-			return chartPosition === 'left' ? 'bottom' : 'left';
 		});
 	}
 
@@ -64,9 +57,8 @@
 	<button class="btn btn-sm" on:click={openClearMapModal}>clear</button>
 	<button class="btn btn-sm" on:click={openMapModal}>maps</button>
 	<button class="btn btn-sm" on:click={openAddCandidateModal}>add candidate</button>
-	<button class="btn btn-sm" on:click={toggleChartPosition}>chart position</button>
+	<button class="btn btn-sm" on:click={openStyle}>style</button>
 	<button class="btn btn-sm" on:click={openChartType}>chart type</button>
 	<button class="btn btn-sm" on:click={openMode}>mode: {$ModeStore}</button>
-	<button class="btn btn-sm" on:click={openTheme}>theme</button>
 	<button class="btn btn-sm" on:click={openLogin}>login</button>
 </div>

--- a/apps/yapms/src/lib/stores/Modals.ts
+++ b/apps/yapms/src/lib/stores/Modals.ts
@@ -44,7 +44,7 @@ const ModeModalStore = writable({
 	open: false
 });
 
-const ThemeModalStore = writable({
+const StyleModalStore = writable({
 	open: false
 });
 
@@ -61,6 +61,6 @@ export {
 	PresetColorsModalStore,
 	ChartTypeModalStore,
 	ModeModalStore,
-	ThemeModalStore,
+	StyleModalStore,
 	LoginModalStore
 };

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -19,8 +19,8 @@
 	import ChartBar from '$lib/components/chartbar/ChartBar.svelte';
 	import PresetColorsModal from '$lib/components/modals/presetcolorsmodal/PresetColorsModal.svelte';
 	import ChartTypeModal from '$lib/components/modals/charttypemodal/ChartTypeModal.svelte';
-	import ThemeModal from '$lib/components/modals/thememodal/ThemeModal.svelte';
 	import AuthModal from '$lib/components/modals/authmodal/AuthModal.svelte';
+	import StyleModal from '$lib/components/modals/stylemodal/StyleModal.svelte';
 
 	const imports = {
 		usa: () => import('$lib/assets/usa.svg?raw'),
@@ -113,6 +113,6 @@
 
 <ModeModal />
 
-<ThemeModal />
+<StyleModal />
 
 <AuthModal />


### PR DESCRIPTION
Preview:
Combined the theme menu and chart position button into a style modal.
![image](https://user-images.githubusercontent.com/13600696/212224854-93dfcf15-53f0-4d37-92cf-ac6edcc58989.png)
![image](https://user-images.githubusercontent.com/13600696/212224941-5fe24a93-10a7-4572-8c20-576a2015dc0b.png)


Code:
Renamed the theme modal to the style modal, and all of the related components/stores.
The chart position buttons are toggles.

closes #80 
