### PR TITLE
Home Page updates from Pocketbase

### DIFF
--- a/apps/pocketbase/config/pb_schema.json
+++ b/apps/pocketbase/config/pb_schema.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "_pb_users_auth_",
+    "name": "users",
+    "type": "auth",
+    "system": false,
+    "schema": [
+      {
+        "id": "users_name",
+        "name": "name",
+        "type": "text",
+        "system": false,
+        "required": false,
+        "unique": false,
+        "options": {
+          "min": null,
+          "max": null,
+          "pattern": ""
+        }
+      },
+      {
+        "id": "users_avatar",
+        "name": "avatar",
+        "type": "file",
+        "system": false,
+        "required": false,
+        "unique": false,
+        "options": {
+          "maxSelect": 1,
+          "maxSize": 5242880,
+          "mimeTypes": [
+            "image/jpg",
+            "image/jpeg",
+            "image/png",
+            "image/svg+xml",
+            "image/gif"
+          ],
+          "thumbs": null
+        }
+      }
+    ],
+    "listRule": "id = @request.auth.id",
+    "viewRule": "id = @request.auth.id",
+    "createRule": "",
+    "updateRule": "id = @request.auth.id",
+    "deleteRule": "id = @request.auth.id",
+    "options": {
+      "allowEmailAuth": true,
+      "allowOAuth2Auth": true,
+      "allowUsernameAuth": true,
+      "exceptEmailDomains": null,
+      "manageRule": null,
+      "minPasswordLength": 8,
+      "onlyEmailDomains": null,
+      "requireEmail": false
+    }
+  },
+  {
+    "id": "glgfha7cmc2ni4a",
+    "name": "updates",
+    "type": "base",
+    "system": false,
+    "schema": [
+      {
+        "id": "ywa5ssgn",
+        "name": "title",
+        "type": "text",
+        "system": false,
+        "required": false,
+        "unique": false,
+        "options": {
+          "min": null,
+          "max": null,
+          "pattern": ""
+        }
+      },
+      {
+        "id": "puejiybj",
+        "name": "description",
+        "type": "text",
+        "system": false,
+        "required": false,
+        "unique": false,
+        "options": {
+          "min": null,
+          "max": null,
+          "pattern": ""
+        }
+      }
+    ],
+    "listRule": "",
+    "viewRule": null,
+    "createRule": null,
+    "updateRule": null,
+    "deleteRule": null,
+    "options": {}
+  }
+]

--- a/apps/yapms/src/lib/components/homepage/HomePageSidebar.svelte
+++ b/apps/yapms/src/lib/components/homepage/HomePageSidebar.svelte
@@ -10,22 +10,24 @@
 	let updates:Record[] = [];
 
 	onMount(async () => {
-		//Request the last 10 update records from pocketbase.
-		$PocketBaseStore.collection('updates').getList(1, 10, {sort: '-created'})
-		.then(data => {
-			updates = data.items
-		}).catch(error => {
+		try {
+			//Request the last 10 update records from pocketbase.
+			const records = await $PocketBaseStore.collection('updates').getList(1, 10, {sort: '-created'});
+			updates = records.items;
+		} catch(error) {
 			console.log(`Failed to fetch updates:\n${error}`);
-		});
+		}
 	});
 </script>
 
 <div class="lg:w-1/5 pl-5 hidden md:flex flex-col h-full justify-between">
 	<div class="overflow-y-auto">
 		<div class="divider">Updates</div>
-		{#each updates as update}
-			<SideBarUpdate title={update.title} description={update.description}></SideBarUpdate>
-		{/each}
+		<div class="flex flex-col gap-y-3">
+			{#each updates as update}
+				<SideBarUpdate title={update.title} description={update.description}></SideBarUpdate>
+			{/each}
+		</div>
 	</div>
 	<div class="mb-4">
 		<div class="divider">Social Links</div>

--- a/apps/yapms/src/lib/components/homepage/HomePageSidebar.svelte
+++ b/apps/yapms/src/lib/components/homepage/HomePageSidebar.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
 	import Fa from 'svelte-fa';
 	import { faDiscord, faGithub, faReddit, faTwitter } from '@fortawesome/free-brands-svg-icons';
+
+	import { onMount } from "svelte";
+	import { PocketBaseStore } from '$lib/stores/PocketBase';
+	import SideBarUpdate from './SideBarUpdate.svelte';
+	import type { Record } from 'pocketbase';
+
+	let updates:Record[] = [];
+
+	onMount(async () => {
+		//Request the last 10 update records from pocketbase.
+		$PocketBaseStore.collection('updates').getList(1, 10, {sort: '-created'})
+		.then(data => {
+			updates = data.items
+		}).catch(error => {
+			console.log(error);
+		});
+	});
 </script>
 
 <div class="lg:w-1/5 pl-5 hidden md:flex flex-col h-full justify-between">
-	<div>
+	<div class="overflow-y-auto">
 		<div class="divider">Updates</div>
-		<p>This will eventually be updated by a server</p>
+		{#each updates as update}
+			<SideBarUpdate title={update.title} description={update.description}></SideBarUpdate>
+		{/each}
 	</div>
 	<div class="mb-4">
 		<div class="divider">Social Links</div>

--- a/apps/yapms/src/lib/components/homepage/HomePageSidebar.svelte
+++ b/apps/yapms/src/lib/components/homepage/HomePageSidebar.svelte
@@ -15,7 +15,7 @@
 		.then(data => {
 			updates = data.items
 		}).catch(error => {
-			console.log(error);
+			console.log(`Failed to fetch updates:\n${error}`);
 		});
 	});
 </script>

--- a/apps/yapms/src/lib/components/homepage/SideBarUpdate.svelte
+++ b/apps/yapms/src/lib/components/homepage/SideBarUpdate.svelte
@@ -3,11 +3,11 @@
     export let description: string
 </script>
 
-<div class="card card-bordered bg-base-300 shadow-md p-3 mb-3">
-    <div class="text-xl text-center md:text-left font-semibold pb-2">
+<div class="card card-bordered bg-base-300 shadow-md p-3">
+    <div class="text-xl text-left font-semibold pb-2">
         {title}
     </div>
-    <div class="text-md text-center md:text-left">
+    <div class="text-md text-left">
         {description}
     </div>
 </div>

--- a/apps/yapms/src/lib/components/homepage/SideBarUpdate.svelte
+++ b/apps/yapms/src/lib/components/homepage/SideBarUpdate.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+    export let title: string
+    export let description: string
+</script>
+
+<div class="card card-bordered bg-base-300 shadow-md p-3 mb-3">
+    <div class="text-xl text-center md:text-left font-semibold pb-2">
+        {title}
+    </div>
+    <div class="text-md text-center md:text-left">
+        {description}
+    </div>
+</div>


### PR DESCRIPTION
This PR changes the updates page on the sidebar of the home page to use updates provided by an "updates" collection in Pocketbase. This collection must be setup like such: 
![image](https://user-images.githubusercontent.com/42476312/212715434-4523bfae-a5b6-49be-9a60-872282a4252b.png)
![image](https://user-images.githubusercontent.com/42476312/212715470-08c9b9ee-26fc-406c-adf4-3805791f0397.png)
(avoid a 403)

The updates sidebar fetches the 10 most recent updates and renders them like such:
![image](https://user-images.githubusercontent.com/42476312/212715797-2d6eed7c-19a1-4dec-8657-af2add417a40.png)

![yapmsDynamicUpdates](https://user-images.githubusercontent.com/42476312/212715982-d4304e19-7ca3-49a8-a389-202167f46f38.gif)

Code changes: 
- Adds new component SideBarUpdate consisting of the appropriate DOM elements for an update.
- Adds a function onMount for the HomePageSidebar component that fetches the 10 latest updates from Pocketbase.
