### PR TITLE
Add install command to use PNPM

### DIFF
--- a/apps/yapms/package.json
+++ b/apps/yapms/package.json
@@ -15,7 +15,8 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint-no-warnings": "prettier --plugin-search-dir . --check . && eslint --max-warnings 0 .",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"install": "pnpm install"
 	},
 	"devDependencies": {
 		"@fortawesome/free-brands-svg-icons": "^6.3.0",


### PR DESCRIPTION
Nixpack looks for an install command to override the default npm install.