### PR TITLE
Remove pocketbase routes & use SDK

### DIFF
--- a/apps/pocketbase/main.go
+++ b/apps/pocketbase/main.go
@@ -4,23 +4,16 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto/md5"
-	"encoding/base64"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
-	"mime/multipart"
-	"net/http"
 	"os"
 
 	"github.com/chromedp/chromedp"
-	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase"
-	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/forms"
-	"github.com/pocketbase/pocketbase/models"
 	"github.com/pocketbase/pocketbase/plugins/migratecmd"
 	"github.com/pocketbase/pocketbase/tools/filesystem"
 
@@ -55,167 +48,91 @@ func main() {
 		return nil
 	})
 
-	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
+	app.OnRecordBeforeCreateRequest().Add(func (e *core.RecordCreateEvent) error {
+		// if the record is in the maps collection, set the hash
+		if e.Record.Collection().Name == "maps" {
 
-		e.Router.AddRoute(echo.Route{
-			Method: http.MethodPost,
-			Path: "/api/yapms.com/map",
-			Handler: func(c echo.Context) error {
+			file := e.UploadedFiles["data"][0]
 
-				// get the maps collection
-				mapsCollection, err := app.Dao().FindCollectionByNameOrId("maps")
-				if err != nil {
-					return err
-				}
-			
-				// create a new record to be inserted
-				record := models.NewRecord(mapsCollection)
-				form := forms.NewRecordUpsert(app, record)
+			reader, err := file.Reader.Open()
+			if err != nil {
+				return err
+			}
+			defer reader.Close()
 
-				// parse the multipart form
-				c.Request().ParseMultipartForm(0)
+			// read the file
+			data, err := ioutil.ReadAll(reader)
+			if err != nil {
+				return err
+			}
 
-				// get the file from the form
-				file, _, err := c.Request().FormFile("data")
-				if err != nil {
-					return err
-				}
-				defer file.Close()
+			// compress the file in memory
+			var compressedData bytes.Buffer
+			gzip := gzip.NewWriter(&compressedData)
+			_, err = gzip.Write(data)
+			if err != nil {
+				return err
+			}
+			err = gzip.Close()
+			if err != nil {
+				return err
+			}
 
-				// read the file
-				data, err := ioutil.ReadAll(file)
-				if err != nil {
-					return err
-				}
+			// create a file from the compressed data
+			newFile, err := filesystem.NewFileFromBytes(compressedData.Bytes(), "data.json.gz")
+			newFile.Name = "data.json.gz"
+			if err != nil {
+				return err
+			}
 
-				// compress the file in memory
-				var compressedData bytes.Buffer
-				gzip := gzip.NewWriter(&compressedData)
-				_, err = gzip.Write(data)
-				if err != nil {
-					return err
-				}
-				err = gzip.Close()
-				if err != nil {
-					return err
-				}
+			// set the file to the new file
+			e.UploadedFiles["data"][0] = newFile	
 
-				// generate a hash of the compressed data
-				hash := md5.Sum(compressedData.Bytes())
-				hashEncoded := base64.StdEncoding.EncodeToString(hash[:])
-				form.LoadData(map[string]any{
-					"hash": hashEncoded,
-				})
-
-				// check if the hash already exists
-				existingRecord, _ := app.Dao().FindFirstRecordByData("maps", "hash", hashEncoded)
-				if existingRecord != nil {
-					return c.JSON(http.StatusOK, MapRouteReturn{
-						Id: existingRecord.Id,
-					})
-				}
-
-				// create a multipart writer to create a form
-				var newMultipartData bytes.Buffer
-				writer := multipart.NewWriter(&newMultipartData)
-				fileWriter, err := writer.CreateFormFile("data", "temp")
-				if err != nil {
-					return err
-				}
-
-				// write the compressed data to memory
-				_, err = fileWriter.Write(compressedData.Bytes())
-				if err != nil {
-					return err
-				}
-				writer.Close()
-
-				// create a new multipart reader
-				newMultipartReader := multipart.NewReader(&newMultipartData, writer.Boundary())
-
-				// read the form from the reader
-				newForm, err := newMultipartReader.ReadForm(0)
-				if err != nil {
-					fmt.Println("ERROR: ", err)
-					return err
-				}
-
-				// create a new file from the form
-				newFile, err := filesystem.NewFileFromMultipart(newForm.File["data"][0])
-				newFile.Name = "data.json.gz"
-				if err != nil {
-					return err
-				}
-
-				// add the file to the form
-				err = form.AddFiles("data", newFile)
-				if err != nil {
-					return err
-				}
-
-				// submit the form & create the record
-				err = form.Submit()
-				if err != nil {
-					return err
-				}
-
-				// create a new browserless context
-				allocatorContext, cancel := chromedp.NewRemoteAllocator(context.Background(), *browserlessConnection)
-				defer cancel()
-				ctx, cancel := chromedp.NewContext(allocatorContext)
-				defer cancel()
-
-				// create a new browserless task
-				var screenshot []byte
-				if err := chromedp.Run(ctx,
-					chromedp.EmulateViewport(1600, 900),
-					chromedp.Navigate(browserlessFrontendURI + "/app?m=" + record.Id),
-					chromedp.WaitReady("#testing-map"),
-					chromedp.FullScreenshot(&screenshot, 100),
-				); err != nil {
-					log.Println(err)
-					// return the new record
-					return c.JSON(http.StatusOK, MapRouteReturn{
-						Id: record.Id,
-					})
-				}
-
-				// create a new file from the screenshot
-				screenshotFile, err := filesystem.NewFileFromBytes(screenshot, "screenshot.png")
-				if err != nil {
-					log.Println(err)
-					// return the new record
-					return c.JSON(http.StatusOK, MapRouteReturn{
-						Id: record.Id,
-					})
-				}
-
-				// add the screenshot to the form
-				form = forms.NewRecordUpsert(app, record)
-				form.AddFiles("screenshot", screenshotFile)
-
-				// submit the form & create the record
-				err = form.Submit()
-				if err != nil {
-					log.Println(err)
-					// return the new record
-					return c.JSON(http.StatusOK, MapRouteReturn{
-						Id: record.Id,
-					})
-				}
-
-				// return the new record
-				return c.JSON(http.StatusOK, MapRouteReturn{
-					Id: record.Id,
-				})
-			},
-			Middlewares: []echo.MiddlewareFunc{
-				apis.ActivityLogger(app),
-			},
-		})
-
+			// change the file name to .json.gz
+			e.Record.Set("data", "data.json.gz")
+		}
 		return nil
+	})
 
+	app.OnRecordAfterCreateRequest().Add(func (e *core.RecordCreateEvent) error {
+		if e.Record.Collection().Name == "maps" {
+
+			// create a screenshot with browserless
+			ctx, cancel := chromedp.NewRemoteAllocator(context.Background(), *browserlessConnection)
+			defer cancel()
+			ctx, cancel = chromedp.NewContext(ctx)
+			defer cancel()
+
+			var screenshotBuffer []byte
+			err := chromedp.Run(ctx,
+				chromedp.EmulateViewport(1600, 900),
+				chromedp.Navigate(browserlessFrontendURI + "/app?m=" + e.Record.Id),
+				chromedp.WaitReady("#testing-map"),
+				chromedp.FullScreenshot(&screenshotBuffer, 100),
+			)
+			if err != nil {
+				fmt.Println("ERROR: ", err)
+				return nil
+			}
+
+			// create a file from the screenshot
+			newFile, err := filesystem.NewFileFromBytes(screenshotBuffer, "screenshot.png")
+			if err != nil {
+				fmt.Println("ERROR: ", err)
+				return nil
+			}
+			newFile.Name = "screenshot.png"
+
+			// update record
+			form := forms.NewRecordUpsert(app, e.Record)
+			form.AddFiles("screenshot", newFile)
+			form.Submit()
+			if err != nil {
+				fmt.Println("ERROR: ", err)
+				return nil
+			}
+		}
+		return nil
 	})
 
 	if err := app.Start(); err != nil {

--- a/apps/pocketbase/main.go
+++ b/apps/pocketbase/main.go
@@ -54,19 +54,20 @@ func main() {
 
 			file := e.UploadedFiles["data"][0]
 
+			// open the file
 			reader, err := file.Reader.Open()
 			if err != nil {
 				return err
 			}
 			defer reader.Close()
 
-			// read the file
+			// get the file data
 			data, err := ioutil.ReadAll(reader)
 			if err != nil {
 				return err
 			}
 
-			// compress the file in memory
+			// compress the data
 			var compressedData bytes.Buffer
 			gzip := gzip.NewWriter(&compressedData)
 			_, err = gzip.Write(data)
@@ -103,6 +104,7 @@ func main() {
 			ctx, cancel = chromedp.NewContext(ctx)
 			defer cancel()
 
+			// take a screenshot
 			var screenshotBuffer []byte
 			err := chromedp.Run(ctx,
 				chromedp.EmulateViewport(1600, 900),

--- a/apps/pocketbase/migrations/1679786589_updated_maps.go
+++ b/apps/pocketbase/migrations/1679786589_updated_maps.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		collection.CreateRule = types.Pointer("@request.auth.verified = true")
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		collection.CreateRule = nil
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/apps/pocketbase/migrations/1679787942_updated_maps.go
+++ b/apps/pocketbase/migrations/1679787942_updated_maps.go
@@ -1,0 +1,73 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models/schema"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		// update
+		edit_data := &schema.SchemaField{}
+		json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "seh7ma4x",
+			"name": "data",
+			"type": "file",
+			"required": true,
+			"unique": false,
+			"options": {
+				"maxSelect": 1,
+				"maxSize": 250000,
+				"mimeTypes": [
+					"application/gzip",
+					"application/json"
+				],
+				"thumbs": []
+			}
+		}`), edit_data)
+		collection.Schema.AddField(edit_data)
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		// update
+		edit_data := &schema.SchemaField{}
+		json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "seh7ma4x",
+			"name": "data",
+			"type": "file",
+			"required": true,
+			"unique": false,
+			"options": {
+				"maxSelect": 1,
+				"maxSize": 250000,
+				"mimeTypes": [
+					"application/gzip"
+				],
+				"thumbs": []
+			}
+		}`), edit_data)
+		collection.Schema.AddField(edit_data)
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/apps/pocketbase/migrations/1679788015_updated_maps.go
+++ b/apps/pocketbase/migrations/1679788015_updated_maps.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		collection.CreateRule = types.Pointer("")
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		collection.CreateRule = nil
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/apps/pocketbase/migrations/1679788407_updated_maps.go
+++ b/apps/pocketbase/migrations/1679788407_updated_maps.go
@@ -1,0 +1,66 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models/schema"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		// update
+		edit_hash := &schema.SchemaField{}
+		json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "eh3qiu7y",
+			"name": "hash",
+			"type": "text",
+			"required": false,
+			"unique": true,
+			"options": {
+				"min": 24,
+				"max": 24,
+				"pattern": ""
+			}
+		}`), edit_hash)
+		collection.Schema.AddField(edit_hash)
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		// update
+		edit_hash := &schema.SchemaField{}
+		json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "eh3qiu7y",
+			"name": "hash",
+			"type": "text",
+			"required": true,
+			"unique": true,
+			"options": {
+				"min": 24,
+				"max": 24,
+				"pattern": ""
+			}
+		}`), edit_hash)
+		collection.Schema.AddField(edit_hash)
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/apps/pocketbase/migrations/1679789008_updated_maps.go
+++ b/apps/pocketbase/migrations/1679789008_updated_maps.go
@@ -1,0 +1,52 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models/schema"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		// remove
+		collection.Schema.RemoveField("eh3qiu7y")
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("tgcm0cd7l7jj0ze")
+		if err != nil {
+			return err
+		}
+
+		// add
+		del_hash := &schema.SchemaField{}
+		json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "eh3qiu7y",
+			"name": "hash",
+			"type": "text",
+			"required": false,
+			"unique": true,
+			"options": {
+				"min": 24,
+				"max": 24,
+				"pattern": ""
+			}
+		}`), del_hash)
+		collection.Schema.AddField(del_hash)
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
+++ b/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
@@ -9,7 +9,8 @@
 	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 	import { page } from '$app/stores';
 	import CheckCircle from '$lib/icons/CheckCircle.svelte';
-	import { PUBLIC_POCKETBASE_URI } from '$env/static/public';
+	import { get } from 'svelte/store';
+	import { PocketBaseStore } from '$lib/stores/PocketBase';
 
 	let files: FileList;
 
@@ -25,24 +26,20 @@
 	}
 
 	async function generateLink() {
-		const blob = new Blob([JSON.stringify(generateJson())], { type: 'application/json' });
-
-		const formData = new FormData();
-		formData.append('data', blob, 'data.json');
-
-		const url = new URL(`${PUBLIC_POCKETBASE_URI}/api/yapms.com/map`);
-
-		copiedLinkID = false;
 		fetchingLinkID = true;
-		const result = await fetch(url, {
-			method: 'POST',
-			body: formData
+
+		const form = new FormData();
+
+		const mapData = new File([JSON.stringify(generateJson())], 'data.json', {
+			type: 'application/json',
 		});
-		const data = await result.json();
-		linkID = data.id;
-		setTimeout(() => {
-			fetchingLinkID = false;
-		}, 1200);
+
+		form.append('data', mapData);
+
+		const pocketbaseStore = get(PocketBaseStore);
+		const record = await pocketbaseStore.collection("maps").create(form);
+		linkID = record.id;
+		fetchingLinkID = false;
 	}
 
 	async function copyLink() {

--- a/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
+++ b/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
@@ -31,13 +31,13 @@
 		const form = new FormData();
 
 		const mapData = new File([JSON.stringify(generateJson())], 'data.json', {
-			type: 'application/json',
+			type: 'application/json'
 		});
 
 		form.append('data', mapData);
 
 		const pocketbaseStore = get(PocketBaseStore);
-		const record = await pocketbaseStore.collection("maps").create(form);
+		const record = await pocketbaseStore.collection('maps').create(form);
 		linkID = record.id;
 		fetchingLinkID = false;
 	}


### PR DESCRIPTION
Feature: Pocketbase has built in capabilities to add records to the database. So I think its better to use that instead of building our own custom routes and using the fetch API.

Code: Removed the route in pocketbase, and used the OnRecordBeforeCreate and OnRecordAfterCreate. These get called whenever a record gets added to the system.

I also removed the hash in the map collection, because I don't think it would actually prevent that much duplicate data. There are so many things yapms can customize, the likelihood of two people making the same map is probably pretty low.

closes #132 