### PR TITLE
Change map selection title to white for all themes

### DIFF
--- a/apps/yapms/src/lib/components/homepage/MapSelectionCard.svelte
+++ b/apps/yapms/src/lib/components/homepage/MapSelectionCard.svelte
@@ -19,7 +19,7 @@
 <div class="card card-bordered w-80 md:w-92 h-48 lg:h-52 bg-base-100 shadow-xl image-full">
 	<figure><img src={`./countrybackgrounds/${bg}.webp`} {alt} /></figure>
 	<div class="card-body items-center text-center">
-		<h2 class="card-title text-primary-content">{name}</h2>
+		<h2 class="card-title text-white">{name}</h2>
 		<div class="grid gap-4" class:grid-cols-2={doubleCols}>
 			{#each links as link}
 				<a


### PR DESCRIPTION
This PR changes the title text color for map selection cards to white in order to maintain contrast across themes.

![image](https://user-images.githubusercontent.com/42476312/228609944-029458e9-8fb7-4c8b-a87d-527891177cf2.png)
old

![image](https://user-images.githubusercontent.com/42476312/228609969-ed282c53-14a4-457d-bedc-313719737505.png)
new

Fixes #137 