### PR TITLE
Fix search bar transparency

### DIFF
--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -16,7 +16,7 @@ body {
 	@apply input input-lg input-bordered border-2 -ml-12 pr-4 pl-14 rounded-md bg-base-200 text-2xl !important;
 }
 [data-svelte-typeahead] .svelte-typeahead-list {
-	@apply mt-2 rounded-md overflow-hidden -ml-12 !important;
+	@apply mt-2 rounded-md overflow-hidden -ml-12 z-50 !important;
 }
 [data-svelte-typeahead] .svelte-typeahead-list li {
 	@apply bg-base-200 text-lg;


### PR DESCRIPTION
This PR adds z-50 to the search bar list, making sure that it displays over everything else:

![image](https://user-images.githubusercontent.com/42476312/229386199-fa098136-c3fe-46ec-b7b5-d5c0568f38ef.png)

Closes #139 