### PR TITLE
Added "None" Chart Type

### DIFF
--- a/apps/yapms/src/lib/components/modals/charttypemodal/ChartTypeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/charttypemodal/ChartTypeModal.svelte
@@ -4,7 +4,7 @@
 	import type { ChartType } from '$lib/types/ChartType';
 	import ModalTitle from '../../modalutilities/ModalTitle.svelte';
 
-	const types = ['pie', 'battle'];
+	const types = ['pie', 'battle', 'none'];
 
 	function close() {
 		ChartTypeModalStore.set({

--- a/apps/yapms/src/lib/types/ChartType.ts
+++ b/apps/yapms/src/lib/types/ChartType.ts
@@ -1,1 +1,1 @@
-export type ChartType = 'battle' | 'pie';
+export type ChartType = 'battle' | 'pie' | 'none';

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -91,7 +91,7 @@
 			class:flex-col-reverse={$ChartPositionStore === 'bottom'}
 			class:flex-row={$ChartPositionStore === 'left'}
 		>
-			<div 
+			<div
 				class="flex justify-center items-center ml-3 mr-3 mt-3 mb-3"
 				class:hidden={$ChartTypeStore === 'none'}
 			>

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -91,7 +91,10 @@
 			class:flex-col-reverse={$ChartPositionStore === 'bottom'}
 			class:flex-row={$ChartPositionStore === 'left'}
 		>
-			<div class="flex justify-center items-center ml-3 mr-3 mt-3 mb-3">
+			<div 
+				class="flex justify-center items-center ml-3 mr-3 mt-3 mb-3"
+				class:hidden={$ChartTypeStore === 'none'}
+			>
 				{#if $ChartTypeStore === 'battle' && $CandidatesStore.length <= 2}
 					<HorizontalBattleChart />
 				{:else if $ChartTypeStore === 'pie'}


### PR DESCRIPTION
This PR adds a "None" chart type that hides the div that the chart resides in.

![image](https://user-images.githubusercontent.com/42476312/230459865-4f5e73f6-ab01-49a2-a301-030742cbaeb0.png)
*When 'none' is selected.*

Summary of code changes:
- Adds 'none' as a possible value for the Chart Type Modal
- Adds 'none' as a possible value for the ChartType type
- Adds a statement to add the hidden class to the chart-containing div when ChartTypeStore is 'none'.