### PR TITLE
remove the sidebar transition

### DIFF
--- a/apps/yapms/src/lib/components/sidebar/SideBar.svelte
+++ b/apps/yapms/src/lib/components/sidebar/SideBar.svelte
@@ -4,30 +4,14 @@
 	import Fa from 'svelte-fa';
 	import { faReddit, faTwitter } from '@fortawesome/free-brands-svg-icons';
 
-	import type { TransitionConfig } from 'svelte/transition';
-
 	import titles from '$lib/assets/other/Titles.json';
 
-	function slideX(node: Element, options: { duration: number }): TransitionConfig {
-		const style = getComputedStyle(node);
-		const width = parseFloat(style.width);
-
-		return {
-			duration: options.duration,
-			css: (_t, u) => `margin-right: ${u * width * -1}px;`
-		};
-	}
-
-	/**
-	 * The title for this page as defined by page path in lib/assets/other/Titles.json.
-	 * Updates when page.url.pathname changes. "YAPms" if title not defined.
-	 */
 	$: title = titles.find((elem) => elem.path === $page.url.pathname)?.title ?? 'YAPms';
 </script>
 
 <div class="divider divider-horizontal w-0 m-0 hidden md:flex" />
 
-<div class="basis-3/12 max-w-md hidden md:inline" transition:slideX={{ duration: 300 }}>
+<div class="basis-3/12 max-w-md hidden md:inline">
 	<div class="flex flex-wrap justify-center gap-2 p-2">
 		<button type="button" class="btn btn-sm gap-2">
 			<Fa icon={faReddit} />


### PR DESCRIPTION
Feature: Removing the transition, eliminates the problem of the map not being centered on first load. Also, I think the transition didn't really add anything to the page load.

Code: Deleted the transition function from the SideBar component.

![image](https://github.com/yapms/yapms/assets/13600696/ad1bffda-04e7-483e-832b-ec3e617b9235)

closes #114 
