### PR TITLE
Beta Modal & Removal of Nonexistent Links

### DIFF
--- a/apps/yapms/src/lib/assets/homedata/MapSelection.json
+++ b/apps/yapms/src/lib/assets/homedata/MapSelection.json
@@ -1,6 +1,6 @@
 [
 	{
-		"title": "Popular Maps",
+		"title": "Current Maps",
 		"cards": [
 			{
 				"name": "United States",
@@ -27,65 +27,6 @@
 						"label": "More",
 						"modal": true,
 						"route": "usa"
-					}
-				]
-			},
-			{
-				"name": "United Kingdom",
-				"bg": "uk",
-				"alt": "Palace of Westminster",
-				"doubleCols": false,
-				"links": [
-					{
-						"label": "House of Commons",
-						"modal": false,
-						"route": "/app/usa/presidential/2022"
-					},
-					{
-						"label": "Historic Counties",
-						"modal": false,
-						"route": "/app/usa/presidential/2022"
-					}
-				]
-			},
-			{
-				"name": "Canada",
-				"bg": "canada",
-				"alt": "Parliament Hill",
-				"doubleCols": false,
-				"links": [
-					{
-						"label": "House of Commons",
-						"modal": false,
-						"route": "/app/usa/presidential/2022"
-					},
-					{
-						"label": "Provinces",
-						"modal": false,
-						"route": "/app/usa/presidential/2022"
-					}
-				]
-			}
-		]
-	},
-	{
-		"title": "Additional Maps",
-		"cards": [
-			{
-				"name": "Australia",
-				"bg": "australia",
-				"alt": "Parliament House",
-				"doubleCols": false,
-				"links": [
-					{
-						"label": "House of Representatives",
-						"modal": false,
-						"route": "/app/usa/presidential/2022"
-					},
-					{
-						"label": "States",
-						"modal": false,
-						"route": "/app/usa/presidential/2022"
 					}
 				]
 			}

--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -7,9 +7,12 @@
 
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box">
-		<h3 class="text-2xl pb-3">
-			{title}
-		</h3>
+		<div class="flex gap-x-2">
+			<slot name="icon" />
+			<h3 class="text-2xl pb-3">
+				{title}
+			</h3>
+		</div>
 
 		<slot name="content" />
 

--- a/apps/yapms/src/lib/components/modals/betamodal/BetaModal.svelte
+++ b/apps/yapms/src/lib/components/modals/betamodal/BetaModal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import ModalTitle from '$lib/components/modalutilities/ModalTitle.svelte';
 	import { BetaModalStore } from '$lib/stores/Modals';
 	import { dev } from '$app/environment';
 	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';

--- a/apps/yapms/src/lib/components/modals/betamodal/BetaModal.svelte
+++ b/apps/yapms/src/lib/components/modals/betamodal/BetaModal.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import ModalTitle from '$lib/components/modalutilities/ModalTitle.svelte';
+	import { BetaModalStore } from '$lib/stores/Modals';
+	import { dev } from '$app/environment';
+	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
+	import Fa from 'svelte-fa';
+	import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons';
+
+	function close() {
+		BetaModalStore.set({
+			...$BetaModalStore,
+			open: false
+		});
+	}
+</script>
+
+<input type="checkbox" class="modal-toggle" checked={!dev && $BetaModalStore.open} />
+<div class="modal modal-bottom lg:modal-middle">
+	<div class="modal-box">
+		<div class="flex gap-x-2 items-start">
+			<ExclamationCircle class="w-9 h-9 text-yellow-500" />
+			<ModalTitle title="YAPms2 is in Beta" />
+		</div>
+		<p>
+			YAPms2 is currently in beta and is unfinished with a limited map catalog and incomplete user
+			interface.
+		</p>
+		<p />
+		<br />
+		<p>
+			You can report bugs, suggest features, and contribute to development on our <a
+				class="text-blue-500 underline"
+				href="https://github.com/yapms/yapms">GitHub</a
+			>
+			or in our <a class="text-blue-500 underline" href="https://discord.gg/Rq5bk3eDwm">Discord</a>.
+			Thank you.
+		</p>
+		<div class="modal-action">
+			<a class="btn gap-2" href="https://github.com/yapms/yapms">
+				<Fa icon={faGithub} />
+				<span>GitHub</span>
+			</a>
+			<a class="btn gap-2" href="https://discord.gg/Rq5bk3eDwm">
+				<Fa icon={faDiscord} />
+				<span>Discord</span>
+			</a>
+			<button class="btn btn-primary" on:click={close}> Okay </button>
+		</div>
+	</div>
+</div>

--- a/apps/yapms/src/lib/components/modals/betamodal/BetaModal.svelte
+++ b/apps/yapms/src/lib/components/modals/betamodal/BetaModal.svelte
@@ -5,6 +5,7 @@
 	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 	import Fa from 'svelte-fa';
 	import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons';
+	import ModalBase from '../ModalBase.svelte';
 
 	function close() {
 		BetaModalStore.set({
@@ -14,37 +15,33 @@
 	}
 </script>
 
-<input type="checkbox" class="modal-toggle" checked={!dev && $BetaModalStore.open} />
-<div class="modal modal-bottom lg:modal-middle">
-	<div class="modal-box">
-		<div class="flex gap-x-2 items-start">
-			<ExclamationCircle class="w-9 h-9 text-yellow-500" />
-			<ModalTitle title="YAPms2 is in Beta" />
-		</div>
-		<p>
-			YAPms2 is currently in beta and is unfinished with a limited map catalog and incomplete user
-			interface.
-		</p>
-		<p />
-		<br />
-		<p>
-			You can report bugs, suggest features, and contribute to development on our <a
-				class="text-blue-500 underline"
-				href="https://github.com/yapms/yapms">GitHub</a
-			>
-			or in our <a class="text-blue-500 underline" href="https://discord.gg/Rq5bk3eDwm">Discord</a>.
-			Thank you.
-		</p>
-		<div class="modal-action">
-			<a class="btn gap-2" href="https://github.com/yapms/yapms">
-				<Fa icon={faGithub} />
-				<span>GitHub</span>
-			</a>
-			<a class="btn gap-2" href="https://discord.gg/Rq5bk3eDwm">
-				<Fa icon={faDiscord} />
-				<span>Discord</span>
-			</a>
-			<button class="btn btn-primary" on:click={close}> Okay </button>
+<ModalBase title="YAPms2 is in Beta" open={!dev && $BetaModalStore.open}>
+	<div slot="icon"><ExclamationCircle class="w-9 h-9 text-yellow-500" /></div>
+	<div slot="content">
+		<div class="flex flex-col gap-y-2">
+			<p>
+				YAPms2 is currently in beta and is unfinished with a limited map catalog and incomplete user
+				interface.
+			</p>
+			<p>
+				You can report bugs, suggest features, and contribute to development on our <a
+					class="link link-primary"
+					href="https://github.com/yapms/yapms">GitHub</a
+				>
+				or in our <a class="link link-primary" href="https://discord.gg/Rq5bk3eDwm">Discord</a>.
+				Thank you.
+			</p>
 		</div>
 	</div>
-</div>
+	<div slot="action">
+		<a class="btn gap-2" href="https://github.com/yapms/yapms">
+			<Fa icon={faGithub} />
+			<span>GitHub</span>
+		</a>
+		<a class="btn gap-2" href="https://discord.gg/Rq5bk3eDwm">
+			<Fa icon={faDiscord} />
+			<span>Discord</span>
+		</a>
+		<button class="btn btn-primary" on:click={close}> Okay </button>
+	</div>
+</ModalBase>

--- a/apps/yapms/src/lib/stores/Modals.ts
+++ b/apps/yapms/src/lib/stores/Modals.ts
@@ -78,6 +78,10 @@ const ThemeModalStore = writable({
 	open: false
 });
 
+const BetaModalStore = writable({
+	open: true
+});
+
 export {
 	EditCandidateModalStore,
 	EditTossupModalStore,
@@ -93,5 +97,6 @@ export {
 	ShareModalStore,
 	LoginModalStore,
 	LoadingErrorModalStore,
-	ThemeModalStore
+	ThemeModalStore,
+	BetaModalStore
 };

--- a/apps/yapms/src/routes/+page.svelte
+++ b/apps/yapms/src/routes/+page.svelte
@@ -12,6 +12,7 @@
 	import { onMount } from 'svelte';
 	import { themeChange } from 'theme-change';
 	import MapSearch from '$lib/components/homepage/MapSearch.svelte';
+	import BetaModal from '$lib/components/modals/betamodal/BetaModal.svelte';
 
 	onMount(() => {
 		themeChange(false);
@@ -76,3 +77,5 @@
 <MoreMapsModal />
 
 <ThemeModal />
+
+<BetaModal />


### PR DESCRIPTION
This PR adds a modal containing a notice that yapms2 is in beta to the home page. This modal will only show up in prod, so to see it you will need to run `npm run build` and then `npm run preview`. I do this by using `!dev` as a condition for the modal to show up.

![image](https://github.com/yapms/yapms/assets/42476312/19fd7c6c-3bdb-465e-9363-edff1d5ce816)


This PR also removes cards on the home page for nations other than the U.S, as those links would lead back to the USA 2024 map and were causing confusion.

Summary of Code Changes:
- Adds BetaModal & BetaModalStore
- Removes countries other than USA from MapSelection.json

Closes #172 and #170