### PR TITLE
Proper selection of SVG when exporting

### DIFF
--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -101,7 +101,7 @@ function newImportedMap(): void {
 }
 
 function exportImportAsSVG(): void {
-	const svg = document.getElementById('importedSVG');
+	const svg = document.getElementById('map-div')?.querySelector<SVGElement>('svg');
 	if (svg) {
 		const regions = get(RegionsStore);
 		svg.setAttribute('candidates', JSON.stringify(get(CandidatesStore)));


### PR DESCRIPTION
This PR fixes an issue where when importing an SVG with an ID other than "importedSVG", you would be unable to export the map as the code was not looking into the map-div like we do elsewhere. 

The only code change here is the SVG being exported will now be found based on being a child of map-div instead of the SVG's ID.