### PR TITLE
Fix browserless screenshot

### DIFF
--- a/apps/pocketbase/support/takeScreenshot.go
+++ b/apps/pocketbase/support/takeScreenshot.go
@@ -23,7 +23,7 @@ func TakeScreenshot(e *core.RecordCreateEvent, app *pocketbase.PocketBase, brows
 	err := chromedp.Run(ctx,
 		chromedp.EmulateViewport(1200, 900),
 		chromedp.Navigate(*browserlessFrontendURI+"/view?m="+e.Record.Id),
-		chromedp.WaitReady("#testing-map"),
+		chromedp.WaitReady("#map-div > svg", chromedp.ByQuery),
 		chromedp.FullScreenshot(&screenshotBuffer, 100),
 	)
 	if err != nil {


### PR DESCRIPTION
Browserless won't screenshot maps without a testing-map id. This will instead wait for an SVG loaded inside the map-div.