### PR TITLE
Set body width using percent

### DIFF
--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -4,8 +4,8 @@
 
 html,
 body {
-	width: 100%;
-	height: 100%;
+	width: 100dvw;
+	height: 100dvh;
 	overflow: hidden;
 }
 

--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -4,8 +4,8 @@
 
 html,
 body {
-	width: 100vw;
-	height: 100vh;
+	width: 100%;
+	height: 100%;
 	overflow: hidden;
 }
 

--- a/apps/yapms/src/routes/+page.svelte
+++ b/apps/yapms/src/routes/+page.svelte
@@ -70,7 +70,7 @@
 	<div class="flex flex-row h-full overflow-hidden">
 		<HomePageSidebar />
 		<div class="divider md:divider-horizontal ml-0 w-0 !mr-0" />
-		<div class="flex-1 md:px-5 overflow-auto overflow-x-clip">
+		<div class="flex-1 md:px-5 overflow-auto overflow-x-clip pb-4">
 			<MapSearch />
 			{#each mapSelectSections as section}
 				<MapSelectionTitle title={section.title} />


### PR DESCRIPTION
This PR fixes an issue where the bottom of a page would be cut off on (certain non-gesture?) mobile devices. The best explanation for this that I have is that 100vh doesn't take into account either the top or bottom bar. I set body height and width to 100% instead of vw and vh and this problem goes away with seemingly no adverse affects on desktop or mobile.

Behavior before: 
![Screenshot_20230707-002309](https://github.com/yapms/yapms/assets/42476312/20d1fbb9-3d75-4c0b-b47f-828e927c4922)
![Screenshot_20230707-002323](https://github.com/yapms/yapms/assets/42476312/9517ec18-0756-4e6f-9c70-ca1079157641)

Behavior after:
![](https://cdn.discordapp.com/attachments/886436241241944065/1126731395310563388/Screenshot_20230707-002749.png)
![](https://cdn.discordapp.com/attachments/886436241241944065/1126731395553828875/Screenshot_20230707-002804.png)

Summary of Code Changes:
- Switches the width and height css rules for html and body to use percent
- Adds some padding to the bottom of the div containing home page content for visual appeal

Closes #102 