### PR TITLE
Reset selected candidate store on map load

### DIFF
--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/LoadRegions.ts
@@ -11,7 +11,8 @@ import {
 	CandidatesStore,
 	CandidateStoreSchema,
 	CandidatesStoreDefault,
-	TossupCandidateStoreDefault
+	TossupCandidateStoreDefault,
+	SelectedCandidateStore
 } from '$lib/stores/Candidates';
 import type Region from '$lib/types/Region';
 import { ModeSchema } from '$lib/types/Mode';
@@ -55,6 +56,10 @@ function createTossupCandidateStore(node: HTMLDivElement) {
 	} catch (error) {
 		console.error('Error Parsing Tossup Candidate Data from Map:\n\n' + error);
 	}
+}
+
+function createSelectedCandidateStore() {
+	SelectedCandidateStore.set(get(TossupCandidateStore));
 }
 
 function findCandidate(id: string) {
@@ -157,6 +162,7 @@ function createRegionStore(node: HTMLDivElement) {
 export function loadRegionsForApp(node: HTMLDivElement): void {
 	createCandidateStore(node);
 	createTossupCandidateStore(node);
+	createSelectedCandidateStore();
 	createDefaultModeStore(node);
 	createRegionStore(node);
 	setCursorStyle();


### PR DESCRIPTION
Code: Set the selected candidate to the tossup, after the tossup candidate is created.

![image](https://github.com/yapms/yapms/assets/13600696/5fc7b351-4a64-4aa2-9084-e5f925d13b44)

closes #218 