### PR TITLE
Remove prefixes & "sticky" modal

### DIFF
--- a/apps/yapms/src/lib/assets/homedata/MapSelection.json
+++ b/apps/yapms/src/lib/assets/homedata/MapSelection.json
@@ -8,7 +8,6 @@
 				"alt": "U.S Capitol",
 				"doubleCols": true,
 				"attribution": "Photo by Andy Feliciotti",
-				"prefix": "USA",
 				"links": [
 					{
 						"label": "President",
@@ -26,26 +25,83 @@
 				"modals": [
 					{
 						"label": "More",
-						"routes": [
-							"/app/usa/presidential/2022",
-							"/app/usa/senate/2024",
-							"/app/usa/house/2024",
-							"/app/usa/governors/2024",
-							"/app/usa/senate/current",
-							"/app/usa/house/current",
-							"/app/usa/governors/current",
-							"/app/usa/dem/primary",
-							"/app/usa/dem/primary",
-							"/app/usa/counties/blank",
-							"/app/usa/senate/blank",
-							"/app/usa/senate/class1",
-							"/app/usa/senate/class2",
-							"/app/usa/senate/class3",
-							"/app/usa/governors/blank",
-							"/app/usa/governors/2022",
-							"/app/usa/governors/2023",
-							"/app/usa/governors/2024",
-							"/app/usa/governors/2025"
+						"buttons": [
+							{
+								"label": "2022 Presidential Election",
+								"route": "/app/usa/presidential/2022"
+							},
+							{
+								"label": "2024 Senate Elections",
+								"route": "/app/usa/senate/2024"
+							},
+							{
+								"label": "House 2024",
+								"route": "/app/usa/house/2024"
+							},
+							{
+								"label": "Governors 2024",
+								"route": "/app/usa/governors/2024"
+							},
+							{
+								"label": "Current Senate",
+								"route": "/app/usa/senate/current"
+							},
+							{
+								"label": "Current House",
+								"route": "/app/usa/house/current"
+							},
+							{
+								"label": "Current Governors",
+								"route": "/app/usa/governors/current"
+							},
+							{
+								"label": "Democratic Primary",
+								"route": "/app/usa/dem/primary"
+							},
+							{
+								"label": "Republican Primary",
+								"route": "/app/usa/rep/primary"
+							},
+							{
+								"label": "Counties",
+								"route": "/app/usa/counties/blank"
+							},
+							{
+								"label": "Senate",
+								"route": "/app/usa/senate/blank"
+							},
+							{
+								"label": "Senate Class 1",
+								"route": "/app/usa/senate/class1"
+							},
+							{
+								"label": "Senate Class 2",
+								"route": "/app/usa/senate/class2"
+							},
+							{
+								"label": "Senate Class 3",
+								"route": "/app/usa/senate/class3"
+							},
+							{
+								"label": "Governors",
+								"route": "/app/usa/governors/blank"
+							},
+							{
+								"label": "Governors 2022",
+								"route": "/app/usa/governors/2022"
+							},
+							{
+								"label": "Governors 2023",
+								"route": "/app/usa/governors/2023"
+							},
+							{
+								"label": "Governors 2024",
+								"route": "/app/usa/governors/2024"
+							},
+							{
+								"label": "Governors 2025",
+								"route": "/app/usa/governors/2025"
+							}
 						]
 					}
 				]
@@ -56,7 +112,6 @@
 				"alt": "Canadian Parliament Hill",
 				"doubleCols": true,
 				"attribution": "Photo by Tetyana Kovyrina",
-				"prefix": "Canadian",
 				"links": [
 					{
 						"label": "Provinces",
@@ -74,13 +129,31 @@
 				"modals": [
 					{
 						"label": "More",
-						"routes": [
-							"/app/can/provinces/blank",
-							"/app/can/commons/blank",
-							"/app/can/senate/blank",
-							"/app/can/commons/2021-results",
-							"/app/can/commons/2019-results",
-							"/app/can/commons/2015-results"
+						"buttons": [
+							{
+								"label": "Provinces",
+								"route": "/app/can/provinces/blank"
+							},
+							{
+								"label": "House of Commons",
+								"route": "/app/can/commons/blank"
+							},
+							{
+								"label": "Senate",
+								"route": "/app/can/senate/blank"
+							},
+							{
+								"label": "2021 House of Commons Results",
+								"route": "/app/can/commons/2021-results"
+							},
+							{
+								"label": "2019 House of Commons Results",
+								"route": "/app/can/commons/2019-results"
+							},
+							{
+								"label": "2015 House of Commons Results",
+								"route": "/app/can/commons/2015-results"
+							}
 						]
 					}
 				]
@@ -91,7 +164,6 @@
 				"alt": "Dutch Binnenhof",
 				"doubleCols": true,
 				"attribution": "Photo by Nikodi on Pixabay",
-				"prefix": "Dutch",
 				"links": [
 					{
 						"label": "Provinces",
@@ -109,12 +181,27 @@
 				"modals": [
 					{
 						"label": "More",
-						"routes": [
-							"/app/nld/provinces/blank",
-							"/app/nld/house/2023-blank",
-							"/app/nld/provincial/2023-blank",
-							"/app/nld/provincial/2023-results",
-							"/app/nld/gemeente/2023-blank"
+						"buttons": [
+							{
+								"label": "Provinces",
+								"route": "/app/nld/provinces/blank"
+							},
+							{
+								"label": "2023 House Elections",
+								"route": "/app/nld/house/2023-blank"
+							},
+							{
+								"label": "Provincial Councils",
+								"route": "/app/nld/provincial/2023-blank"
+							},
+							{
+								"label": "2023 Provincial Councils Results",
+								"route": "/app/nld/provincial/2023-results"
+							},
+							{
+								"label": "2023 Gemeente",
+								"route": "/app/nld/gemeente/2023-blank"
+							}
 						]
 					}
 				]
@@ -130,7 +217,6 @@
 				"alt": "U.S Capitol",
 				"doubleCols": true,
 				"attribution": "Photo by Lawrence Jackson",
-				"prefix": "USA",
 				"links": [
 					{
 						"label": "2022",
@@ -148,23 +234,71 @@
 				"modals": [
 					{
 						"label": "More",
-						"routes": [
-							"/app/usa/house/2022",
-							"/app/usa/house/2020",
-							"/app/usa/house/2018",
-							"/app/usa/house/2016",
-							"/app/usa/house/2014",
-							"/app/usa/house/2012",
-							"/app/usa/house/2010",
-							"/app/usa/house/2008",
-							"/app/usa/house/2006",
-							"/app/usa/house/2004",
-							"/app/usa/house/2002",
-							"/app/usa/house/2000",
-							"/app/usa/house/1998",
-							"/app/usa/house/1996",
-							"/app/usa/house/1994",
-							"/app/usa/house/1992"
+						"buttons": [
+							{
+								"label": "House 2022",
+								"route": "/app/usa/house/2022"
+							},
+							{
+								"label": "House 2020",
+								"route": "/app/usa/house/2020"
+							},
+							{
+								"label": "House 2018",
+								"route": "/app/usa/house/2018"
+							},
+							{
+								"label": "House 2016",
+								"route": "/app/usa/house/2016"
+							},
+							{
+								"label": "House 2014",
+								"route": "/app/usa/house/2014"
+							},
+							{
+								"label": "House 2012",
+								"route": "/app/usa/house/2012"
+							},
+							{
+								"label": "House 2010",
+								"route": "/app/usa/house/2010"
+							},
+							{
+								"label": "House 2008",
+								"route": "/app/usa/house/2008"
+							},
+							{
+								"label": "House 2006",
+								"route": "/app/usa/house/2006"
+							},
+							{
+								"label": "House 2004",
+								"route": "/app/usa/house/2004"
+							},
+							{
+								"label": "House 2002",
+								"route": "/app/usa/house/2002"
+							},
+							{
+								"label": "House 2000",
+								"route": "/app/usa/house/2000"
+							},
+							{
+								"label": "House 1998",
+								"route": "/app/usa/house/1998"
+							},
+							{
+								"label": "House 1996",
+								"route": "/app/usa/house/1996"
+							},
+							{
+								"label": "House 1994",
+								"route": "/app/usa/house/1994"
+							},
+							{
+								"label": "House 1992",
+								"route": "/app/usa/house/1992"
+							}
 						]
 					}
 				]

--- a/apps/yapms/src/lib/assets/homedata/MapSelection.json
+++ b/apps/yapms/src/lib/assets/homedata/MapSelection.json
@@ -8,6 +8,7 @@
 				"alt": "U.S Capitol",
 				"doubleCols": true,
 				"attribution": "Photo by Andy Feliciotti",
+				"prefix": "USA",
 				"links": [
 					{
 						"label": "President",
@@ -55,6 +56,7 @@
 				"alt": "Canadian Parliament Hill",
 				"doubleCols": true,
 				"attribution": "Photo by Tetyana Kovyrina",
+				"prefix": "Canadian",
 				"links": [
 					{
 						"label": "Provinces",
@@ -89,6 +91,7 @@
 				"alt": "Dutch Binnenhof",
 				"doubleCols": true,
 				"attribution": "Photo by Nikodi on Pixabay",
+				"prefix": "Dutch",
 				"links": [
 					{
 						"label": "Provinces",
@@ -127,6 +130,7 @@
 				"alt": "U.S Capitol",
 				"doubleCols": true,
 				"attribution": "Photo by Lawrence Jackson",
+				"prefix": "USA",
 				"links": [
 					{
 						"label": "2022",

--- a/apps/yapms/src/lib/components/homepage/MapSelectionCard.svelte
+++ b/apps/yapms/src/lib/components/homepage/MapSelectionCard.svelte
@@ -8,14 +8,12 @@
 	export let alt: string;
 	export let doubleCols: boolean;
 	export let attribution: string;
-	export let prefix: string;
 	export let links: HomeLinkData[];
 	export let modals: HomeModalData[];
 
-	function openMoreModal(keys: string[]) {
+	function openMoreModal(buttons: HomeLinkData[]) {
 		MoreMapsModalStore.set({
-			keys,
-			prefix: prefix,
+			buttons,
 			title: name,
 			open: true
 		});
@@ -34,7 +32,7 @@
 				<button
 					class="btn btn-sm btn-primary w-full"
 					on:click={() => {
-						openMoreModal(modal.routes);
+						openMoreModal(modal.buttons);
 					}}
 					>{modal.label}
 				</button>

--- a/apps/yapms/src/lib/components/homepage/MapSelectionCard.svelte
+++ b/apps/yapms/src/lib/components/homepage/MapSelectionCard.svelte
@@ -8,12 +8,14 @@
 	export let alt: string;
 	export let doubleCols: boolean;
 	export let attribution: string;
+	export let prefix: string;
 	export let links: HomeLinkData[];
 	export let modals: HomeModalData[];
 
 	function openMoreModal(keys: string[]) {
 		MoreMapsModalStore.set({
 			keys,
+			prefix: prefix,
 			title: name,
 			open: true
 		});

--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -1,23 +1,42 @@
 <script lang="ts">
 	export let open: boolean;
 	export let title: string;
+
+	export let stickyTitle = false;
+	export let stickyAction = false;
 </script>
 
 <input type="checkbox" class="modal-toggle" checked={open} />
 
 <div class="modal modal-bottom lg:modal-middle">
-	<div class="modal-box">
-		<div class="flex gap-x-2">
-			<slot name="icon" />
-			<h3 class="text-2xl pb-3">
-				{title}
-			</h3>
+	<div class="modal-box p-0 flex flex-col">
+		<div
+			class="bg-base-100 pt-6"
+			class:border-b={stickyTitle}
+			class:border-base-content={stickyAction}
+		>
+			<div class="flex gap-x-2 ml-6">
+				<slot name="icon" />
+				<h3 class="text-2xl pb-3">
+					{title}
+				</h3>
+			</div>
 		</div>
 
-		<slot name="content" />
+		<div class="px-6 flex-1" class:overflow-y-auto={stickyAction || stickyTitle}>
+			<slot name="content" />
+		</div>
 
-		<div class="modal-action">
-			<slot name="action" />
+		<div
+			class="modal-action bg-base-100 pb-6"
+			class:mt-0={stickyAction}
+			class:pt-3={stickyAction}
+			class:border-t={stickyAction}
+			class:border-base-content={stickyAction}
+		>
+			<div class="mr-6">
+				<slot name="action" />
+			</div>
 		</div>
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -2,8 +2,7 @@
 	export let open: boolean;
 	export let title: string;
 
-	export let stickyTitle = false;
-	export let stickyAction = false;
+	export let sticky = false;
 </script>
 
 <input type="checkbox" class="modal-toggle" checked={open} />
@@ -12,8 +11,8 @@
 	<div class="modal-box p-0 flex flex-col">
 		<div
 			class="bg-base-100 pt-6"
-			class:border-b={stickyTitle}
-			class:border-base-content={stickyAction}
+			class:border-b={sticky}
+			class:border-base-content={sticky}
 		>
 			<div class="flex gap-x-2 ml-6">
 				<slot name="icon" />
@@ -23,16 +22,16 @@
 			</div>
 		</div>
 
-		<div class="px-6 flex-1" class:overflow-y-auto={stickyAction || stickyTitle}>
+		<div class="px-6 flex-1" class:overflow-y-auto={sticky}>
 			<slot name="content" />
 		</div>
 
 		<div
 			class="modal-action bg-base-100 pb-6"
-			class:mt-0={stickyAction}
-			class:pt-3={stickyAction}
-			class:border-t={stickyAction}
-			class:border-base-content={stickyAction}
+			class:mt-0={sticky}
+			class:pt-3={sticky}
+			class:border-t={sticky}
+			class:border-base-content={sticky}
 		>
 			<div class="mr-6">
 				<slot name="action" />

--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -9,11 +9,7 @@
 
 <div class="modal modal-bottom lg:modal-middle">
 	<div class="modal-box p-0 flex flex-col">
-		<div
-			class="bg-base-100 pt-6"
-			class:border-b={sticky}
-			class:border-base-content={sticky}
-		>
+		<div class="bg-base-100 pt-6" class:border-b={sticky} class:border-base-content={sticky}>
 			<div class="flex gap-x-2 ml-6">
 				<slot name="icon" />
 				<h3 class="text-2xl pb-3">

--- a/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
@@ -12,12 +12,17 @@
 	$: maps = titles.filter((title) => $MoreMapsModalStore.keys.indexOf(title.path) !== -1);
 </script>
 
-<ModalBase title="{$MoreMapsModalStore.title} Maps" open={$MoreMapsModalStore.open}>
+<ModalBase
+	title="{$MoreMapsModalStore.title} Maps"
+	open={$MoreMapsModalStore.open}
+	stickyTitle={true}
+	stickyAction={true}
+>
 	<div slot="content">
-		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly">
+		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly my-3">
 			{#each maps as link}
 				<a class="w-2/3 lg:w-1/2 btn btn-primary gap-1" href={link.path} on:click={close}>
-					{link.title.replace($MoreMapsModalStore.prefix,'').toUpperCase()}
+					{link.title.replace($MoreMapsModalStore.prefix, '').toUpperCase()}
 				</a>
 			{/each}
 		</div>

--- a/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
@@ -15,8 +15,7 @@
 <ModalBase
 	title="{$MoreMapsModalStore.title} Maps"
 	open={$MoreMapsModalStore.open}
-	stickyTitle={true}
-	stickyAction={true}
+	sticky
 >
 	<div slot="content">
 		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly my-3">

--- a/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
@@ -17,7 +17,7 @@
 		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly">
 			{#each maps as link}
 				<a class="w-2/3 lg:w-1/2 btn btn-primary gap-1" href={link.path} on:click={close}>
-					{link.title.toUpperCase()}
+					{link.title.replace($MoreMapsModalStore.prefix,'').toUpperCase()}
 				</a>
 			{/each}
 		</div>

--- a/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
@@ -12,11 +12,7 @@
 	$: maps = titles.filter((title) => $MoreMapsModalStore.keys.indexOf(title.path) !== -1);
 </script>
 
-<ModalBase
-	title="{$MoreMapsModalStore.title} Maps"
-	open={$MoreMapsModalStore.open}
-	sticky
->
+<ModalBase title="{$MoreMapsModalStore.title} Maps" open={$MoreMapsModalStore.open} sticky>
 	<div slot="content">
 		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly my-3">
 			{#each maps as link}

--- a/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { MoreMapsModalStore } from '$lib/stores/HomeModals';
-	import titles from '$lib/assets/other/Titles.json';
 	import ModalBase from '../ModalBase.svelte';
 	function close() {
 		MoreMapsModalStore.set({
@@ -8,16 +7,14 @@
 			open: false
 		});
 	}
-
-	$: maps = titles.filter((title) => $MoreMapsModalStore.keys.indexOf(title.path) !== -1);
 </script>
 
 <ModalBase title="{$MoreMapsModalStore.title} Maps" open={$MoreMapsModalStore.open} sticky>
 	<div slot="content">
 		<div class="tabs flex-row lg:flex-col flex-end items-center space-y-2 justify-evenly my-3">
-			{#each maps as link}
-				<a class="w-2/3 lg:w-1/2 btn btn-primary gap-1" href={link.path} on:click={close}>
-					{link.title.replace($MoreMapsModalStore.prefix, '').toUpperCase()}
+			{#each $MoreMapsModalStore.buttons as button}
+				<a class="w-2/3 lg:w-1/2 btn btn-primary gap-1" href={button.route} on:click={close}>
+					{button.label.toUpperCase()}
 				</a>
 			{/each}
 		</div>

--- a/apps/yapms/src/lib/stores/HomeModals.ts
+++ b/apps/yapms/src/lib/stores/HomeModals.ts
@@ -3,6 +3,7 @@ import { writable } from 'svelte/store';
 const MoreMapsModalStore = writable({
 	open: false,
 	title: '',
+	prefix: '',
 	keys: [''] //Used to match Titles.json
 });
 

--- a/apps/yapms/src/lib/stores/HomeModals.ts
+++ b/apps/yapms/src/lib/stores/HomeModals.ts
@@ -1,10 +1,10 @@
+import type { HomeLinkData } from '$lib/types/HomeData';
 import { writable } from 'svelte/store';
 
 const MoreMapsModalStore = writable({
 	open: false,
 	title: '',
-	prefix: '',
-	keys: [''] //Used to match Titles.json
+	buttons: new Array<HomeLinkData>() //Used to match Titles.json
 });
 
 export { MoreMapsModalStore };

--- a/apps/yapms/src/lib/types/HomeData.ts
+++ b/apps/yapms/src/lib/types/HomeData.ts
@@ -5,7 +5,7 @@ type HomeLinkData = {
 
 type HomeModalData = {
 	label: string;
-	routes: string[];
+	buttons: HomeLinkData[];
 };
 
 export type { HomeLinkData, HomeModalData };

--- a/apps/yapms/src/routes/+page.svelte
+++ b/apps/yapms/src/routes/+page.svelte
@@ -82,6 +82,7 @@
 							alt={card.alt}
 							doubleCols={card.doubleCols}
 							attribution={card.attribution}
+							prefix={card.prefix}
 							links={card.links}
 							modals={card.modals}
 						/>

--- a/apps/yapms/src/routes/+page.svelte
+++ b/apps/yapms/src/routes/+page.svelte
@@ -82,7 +82,6 @@
 							alt={card.alt}
 							doubleCols={card.doubleCols}
 							attribution={card.attribution}
-							prefix={card.prefix}
 							links={card.links}
 							modals={card.modals}
 						/>


### PR DESCRIPTION
This PR adds a "prefix" property to cards in MapSelection.json that is used to filter out the specified text in titles in MoreMapsModal. It also adds an optional "sticky" property to ModalBase that makes the title and action bars stick in place as you scroll.

Summary of Code Changes:
- Adds "prefix" to MapSelection.json
  - Adds a prefix property to MoreMapsModalStore
  - Adds logic for the prefix to be replaced in MoreMapsModal
  - Sets prefixes for existing cards
- Adds sticky property to ModalBase
  - Adds conditional classes to ModalBase to make title/action bars sticky
  - Makes MoreMapsModal 'sticky'