### PR TITLE
Tell Svelte which routes to render

### DIFF
--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.server.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.server.ts
@@ -1,1 +1,19 @@
+import titles from '$lib/assets/other/Titles.json';
+
+/** @type {import('./$types').EntryGenerator} */
+export function entries() {
+	return titles.map((title) => {
+		let path = title.path;
+		path = path.replace('/app/', '');
+		const country = path.match(/.+?(?=\/)/)?.[0];
+		path = path.replace(`${country}/`, '');
+		const map = path.match(/.+?(?=\/)/)?.[0];
+		const year = path.replace(`${map}/`, '');
+		if (country === undefined || map === undefined) {
+			return { country: 'usa', map: 'presidential', year: '2022' };
+		}
+		return { country, map, year };
+	});
+}
+
 export const prerender = true;

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.server.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.server.ts
@@ -3,16 +3,11 @@ import titles from '$lib/assets/other/Titles.json';
 /** @type {import('./$types').EntryGenerator} */
 export function entries() {
 	return titles.map((title) => {
-		let path = title.path;
-		path = path.replace('/app/', '');
-		const country = path.match(/.+?(?=\/)/)?.[0];
-		path = path.replace(`${country}/`, '');
-		const map = path.match(/.+?(?=\/)/)?.[0];
-		const year = path.replace(`${map}/`, '');
-		if (country === undefined || map === undefined) {
+		const params = title.path.split('/');
+		if (params[2] === undefined || params[3] === undefined || params[4] === undefined) {
 			return { country: 'usa', map: 'presidential', year: '2022' };
 		}
-		return { country, map, year };
+		return { country: params[2], map: params[3], year: params[4] };
 	});
 }
 


### PR DESCRIPTION
This PR fixes a bug where going to a route not located directly on the home page would return a 404. For instance https://yapms2.com/app/de/folketing/blank will return a 404.

This is caused by Svelte not prerendering this routes. If we remove prerendering for [country]/[map]/[year], it is fixed, but we lose speed as clients have to build the page themselves. This PR tells Svelte which routes to prerender based on Titles.json, which will include any map a user would ever hit.

To test this, do `npm run build` in apps/yapms followed by `npm run preview` then navigate to a route that doesn't appear on the home page.

Summary of Code Changes:
- Adds an [entries](https://kit.svelte.dev/docs/page-options#entries) function for [country]/[map]/[year] to tell Svelte what to prerender.