### PR TITLE
Fix map oversensitivity on mobile

### DIFF
--- a/apps/yapms/src/lib/stores/regions/Regions.ts
+++ b/apps/yapms/src/lib/stores/regions/Regions.ts
@@ -154,7 +154,7 @@ export const setPointerEvents = (): void => {
 			continue;
 		}
 
-		region.nodes.region.onpointerdown = () => {
+		region.nodes.region.onclick = () => {
 			const currentMode = get(ModeStore);
 			switch (currentMode) {
 				case 'fill':

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
@@ -9,7 +9,10 @@ function applyPanZoom(mapBind: HTMLDivElement): PanZoom | undefined {
 			maxZoom: 100,
 			smoothScroll: false,
 			autocenter: true,
-			zoomDoubleClickSpeed: 1
+			zoomDoubleClickSpeed: 1,
+			onTouch: function() {
+				return !1
+			}
 		});
 		if (svg.hasAttribute('auto-border-stroke-width')) {
 			const inputParser = z.number().positive().finite();

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
@@ -11,7 +11,7 @@ function applyPanZoom(mapBind: HTMLDivElement): PanZoom | undefined {
 			autocenter: true,
 			zoomDoubleClickSpeed: 1,
 			onTouch: function() {
-				return !1
+				return false;
 			}
 		});
 		if (svg.hasAttribute('auto-border-stroke-width')) {

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/initialize/ApplyPanZoom.ts
@@ -10,7 +10,7 @@ function applyPanZoom(mapBind: HTMLDivElement): PanZoom | undefined {
 			smoothScroll: false,
 			autocenter: true,
 			zoomDoubleClickSpeed: 1,
-			onTouch: function() {
+			onTouch: function () {
 				return false;
 			}
 		});


### PR DESCRIPTION
This PR changes our click event to onclick and takes a panzoom setting from yapms1 (seemingly inspired by [this documentation](                })) to make sure that click actually works on mobile. This fixes #229 where the map would fill when you went to pan the map.