### PR TITLE
Remove touch actions.

### DIFF
--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -7,6 +7,7 @@ body {
 	width: 100dvw;
 	height: 100dvh;
 	overflow: hidden;
+	touch-action: none;
 }
 
 [data-svelte-typeahead] {


### PR DESCRIPTION
Code: This should remove pinch to zoom, on mobile. This allows the user to only zoom in on the map instead of the entire web page.