### PR TITLE
Prevent closing of MoreMapsModal when opening in new tab

### DIFF
--- a/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/moremapsmodal/MoreMapsModal.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import { MoreMapsModalStore } from '$lib/stores/HomeModals';
 	import ModalBase from '../ModalBase.svelte';
-	function close() {
-		MoreMapsModalStore.set({
-			...$MoreMapsModalStore,
-			open: false
-		});
+	function close(event: MouseEvent) {
+		if (!event.ctrlKey) {
+			MoreMapsModalStore.set({
+				...$MoreMapsModalStore,
+				open: false
+			});
+		}
 	}
 </script>
 


### PR DESCRIPTION
This PR prevents MoreMapsModal from closing when a link is opened in a new tab using the control key. You can open multiple maps quickly this way.