### PR TITLE
reapplyPanZoom on chart changes

### DIFF
--- a/apps/yapms/src/lib/components/mapchartcontainer/MapChartContainer.svelte
+++ b/apps/yapms/src/lib/components/mapchartcontainer/MapChartContainer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { afterUpdate } from 'svelte';
+	import CandidateBoxContainer from '../candidatebox/CandidateBoxContainer.svelte';
+	import ChartArea from '../chartarea/ChartArea.svelte';
+	import { ChartPositionStore } from '$lib/stores/Chart';
+	import { reapplyPanZoom } from '$lib/utils/applyPanZoom';
+
+	afterUpdate(reapplyPanZoom);
+</script>
+
+<div
+	class="flex flex-grow basis-9/12"
+	class:flex-col-reverse={$ChartPositionStore === 'bottom'}
+	class:flex-row={$ChartPositionStore === 'left'}
+>
+	<ChartArea />
+	<div class="overflow-hidden w-full h-full">
+		<CandidateBoxContainer />
+		<slot />
+	</div>
+</div>

--- a/apps/yapms/src/lib/components/modals/chartoptionsmodal/ChartOptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/chartoptionsmodal/ChartOptionsModal.svelte
@@ -4,6 +4,7 @@
 	import type { ChartType } from '$lib/types/ChartType';
 	import ModalBase from '../ModalBase.svelte';
 	import type ChartPosition from '$lib/types/ChartPosition';
+	import { reapplyPanZoom } from '$lib/utils/applyPanZoom';
 
 	const chartTypeValues = ['pie', 'battle', 'none'];
 	const chartPositionValues = ['bottom', 'left'];
@@ -17,10 +18,12 @@
 
 	function setChartType(id: string) {
 		ChartTypeStore.set(id as ChartType);
+		reapplyPanZoom();
 	}
 
 	function setChartPosition(id: string) {
 		ChartPositionStore.set(id as ChartPosition);
+		reapplyPanZoom();
 	}
 </script>
 

--- a/apps/yapms/src/lib/components/sidebar/SideBar.svelte
+++ b/apps/yapms/src/lib/components/sidebar/SideBar.svelte
@@ -3,11 +3,15 @@
 	import titles from '$lib/assets/other/Titles.json';
 	import { PocketBaseStore } from '$lib/stores/PocketBase';
 	import { SideBarStore } from '$lib/stores/SideBar';
+	import { reapplyPanZoom } from '$lib/utils/applyPanZoom';
 	import SavedMaps from './sections/savedmaps/SavedMaps.svelte';
 	import { faReddit, faTwitter } from '@fortawesome/free-brands-svg-icons';
+	import { afterUpdate } from 'svelte';
 	import Fa from 'svelte-fa';
 
 	$: title = titles.find((elem) => elem.path === $page.url.pathname)?.title ?? 'YAPms';
+
+	afterUpdate(reapplyPanZoom);
 </script>
 
 {#if $SideBarStore}

--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -1,17 +1,11 @@
 import panzoom, { type PanZoom } from 'panzoom';
 import z from 'zod';
 
-let panzoomInstance: PanZoom;
-let svg: SVGElement;
+let panzoomInstance: PanZoom | undefined;
+let savedSVG: SVGElement | undefined;
 
-function storeSVGForPan(mapBind: HTMLDivElement) {
-	const foundSVG = mapBind.querySelector<SVGElement>('svg'); //We can do this since the only child of node is the map svg itself.
-	if (foundSVG !== null) {
-		svg = foundSVG; //We can do this since the only child of node is the map svg itself.
-	}
-}
-
-function applyPanZoom(): PanZoom | undefined {
+function applyPanZoom(svg: SVGElement) {
+	savedSVG = svg;
 	panzoomInstance = panzoom(svg, {
 		minZoom: 0.5,
 		maxZoom: 100,
@@ -36,17 +30,20 @@ function applyPanZoom(): PanZoom | undefined {
 
 			adjustStroke(svg, initStroke, strokeUpper, panzoomInstance.getTransform().scale);
 			panzoomInstance.on('zoom', (e: PanZoom) => {
-				adjustStroke(svg, initStroke, strokeUpper, e.getTransform().scale);
+				if (svg !== undefined) {
+					adjustStroke(svg, initStroke, strokeUpper, e.getTransform().scale);
+				}
 			});
 		}
 	}
-	return panzoomInstance;
 }
 
-function reapplyPanZoom(): PanZoom | undefined {
+function reapplyPanZoom() {
+	if (panzoomInstance === undefined || savedSVG === undefined) {
+		return;
+	}
 	panzoomInstance.dispose();
-	setTimeout(applyPanZoom, 0);
-	return panzoomInstance;
+	applyPanZoom(savedSVG);
 }
 
 function adjustStroke(
@@ -64,4 +61,4 @@ function adjustStroke(
 	}
 }
 
-export { storeSVGForPan, applyPanZoom, reapplyPanZoom };
+export { applyPanZoom, reapplyPanZoom };

--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -1,39 +1,54 @@
 import panzoom, { type PanZoom } from 'panzoom';
 import z from 'zod';
 
-function applyPanZoom(mapBind: HTMLDivElement): PanZoom | undefined {
-	const svg = mapBind.querySelector<SVGElement>('svg'); //We can do this since the only child of node is the map svg itself.
-	if (svg) {
-		const panzoomInstance = panzoom(svg, {
-			minZoom: 0.5,
-			maxZoom: 100,
-			smoothScroll: false,
-			autocenter: true,
-			zoomDoubleClickSpeed: 1,
-			onTouch: function () {
-				return false;
-			}
-		});
-		if (svg.hasAttribute('auto-border-stroke-width')) {
-			const inputParser = z.number().positive().finite();
+let panzoomInstance: PanZoom;
+let svg: SVGElement;
 
-			const initStroke = Number(svg.getAttribute('auto-border-stroke-width'));
-			const initStrokeValid = inputParser.safeParse(initStroke).success;
-			if (initStrokeValid) {
-				let strokeUpper: number | null = Number(svg.getAttribute('auto-border-stroke-width-limit'));
-				const strokeUpperValid = inputParser.safeParse(strokeUpper).success;
-				if (!strokeUpperValid) {
-					strokeUpper = null;
-				}
-
-				adjustStroke(svg, initStroke, strokeUpper, panzoomInstance.getTransform().scale);
-				panzoomInstance.on('zoom', (e: PanZoom) => {
-					adjustStroke(svg, initStroke, strokeUpper, e.getTransform().scale);
-				});
-			}
-		}
-		return panzoomInstance;
+function storeSVGForPan(mapBind: HTMLDivElement) {
+	const foundSVG = mapBind.querySelector<SVGElement>('svg'); //We can do this since the only child of node is the map svg itself.
+	if (foundSVG !== null) {
+		svg = foundSVG; //We can do this since the only child of node is the map svg itself.
 	}
+}
+
+function applyPanZoom(): PanZoom | undefined {
+	panzoomInstance = panzoom(svg, {
+		minZoom: 0.5,
+		maxZoom: 100,
+		smoothScroll: false,
+		autocenter: true,
+		zoomDoubleClickSpeed: 1,
+		onTouch: function () {
+			return false;
+		}
+	});
+	if (svg.hasAttribute('auto-border-stroke-width')) {
+		const inputParser = z.number().positive().finite();
+
+		const initStroke = Number(svg.getAttribute('auto-border-stroke-width'));
+		const initStrokeValid = inputParser.safeParse(initStroke).success;
+		if (initStrokeValid) {
+			let strokeUpper: number | null = Number(svg.getAttribute('auto-border-stroke-width-limit'));
+			const strokeUpperValid = inputParser.safeParse(strokeUpper).success;
+			if (!strokeUpperValid) {
+				strokeUpper = null;
+			}
+
+			adjustStroke(svg, initStroke, strokeUpper, panzoomInstance.getTransform().scale);
+			panzoomInstance.on('zoom', (e: PanZoom) => {
+				adjustStroke(svg, initStroke, strokeUpper, e.getTransform().scale);
+			});
+		}
+	}
+	return panzoomInstance;
+}
+
+function reapplyPanZoom(): PanZoom | undefined {
+	if (panzoomInstance.getTransform().scale <= 1.1) {
+		panzoomInstance.dispose();
+		setTimeout(applyPanZoom, 0);
+	}
+	return panzoomInstance;
 }
 
 function adjustStroke(
@@ -51,4 +66,4 @@ function adjustStroke(
 	}
 }
 
-export default applyPanZoom;
+export { storeSVGForPan, applyPanZoom, reapplyPanZoom };

--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -44,10 +44,8 @@ function applyPanZoom(): PanZoom | undefined {
 }
 
 function reapplyPanZoom(): PanZoom | undefined {
-	if (panzoomInstance.getTransform().scale <= 1.1) {
-		panzoomInstance.dispose();
-		setTimeout(applyPanZoom, 0);
-	}
+	panzoomInstance.dispose();
+	setTimeout(applyPanZoom, 0);
 	return panzoomInstance;
 }
 

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -25,9 +25,8 @@
 	import { browser } from '$app/environment';
 	import NavBar from '$lib/components/navbar/NavBar.svelte';
 	import SideBar from '$lib/components/sidebar/SideBar.svelte';
-	import { ChartPositionStore } from '$lib/stores/Chart';
-	import CandidateBoxContainer from '$lib/components/candidatebox/CandidateBoxContainer.svelte';
-	import ChartArea from '$lib/components/chartarea/ChartArea.svelte';
+	import { reapplyPanZoom } from '$lib/utils/applyPanZoom';
+	import MapChartContainer from '$lib/components/mapchartcontainer/MapChartContainer.svelte';
 
 	if (browser) {
 		const url = get(page).url;
@@ -59,22 +58,14 @@
 	<title>YAPms</title>
 </svelte:head>
 
-<svelte:window on:keydown={handleKeyDown} on:keyup={handleKeyUp} />
+<svelte:window on:keydown={handleKeyDown} on:keyup={handleKeyUp} on:resize={reapplyPanZoom} />
 
 <div class="flex flex-col h-full">
 	<NavBar />
 	<div class="flex flex-row h-full overflow-hidden">
-		<div
-			class="flex flex-grow basis-9/12"
-			class:flex-col-reverse={$ChartPositionStore === 'bottom'}
-			class:flex-row={$ChartPositionStore === 'left'}
-		>
-			<ChartArea />
-			<div class="overflow-hidden w-full h-full">
-				<CandidateBoxContainer />
-				<slot />
-			</div>
-		</div>
+		<MapChartContainer>
+			<slot />
+		</MapChartContainer>
 		<SideBar />
 	</div>
 </div>

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/stores';
 	import { MapInsetsStore } from '$lib/stores/MapInsetsStore';
 	import { LoadedMapStore } from '$lib/stores/LoadedMap';
-	import applyPanZoom from '$lib/utils/applyPanZoom';
+	import { storeSVGForPan, applyPanZoom } from '$lib/utils/applyPanZoom';
 	import { loadRegionsForApp } from '$lib/utils/loadRegions';
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
@@ -37,7 +37,8 @@
 	let isLoaded = false;
 
 	function setupMap(node: HTMLDivElement) {
-		applyPanZoom(node);
+		storeSVGForPan(node);
+		applyPanZoom();
 		loadRegionsForApp(node);
 		isLoaded = true;
 	}

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/+page.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/stores';
 	import { MapInsetsStore } from '$lib/stores/MapInsetsStore';
 	import { LoadedMapStore } from '$lib/stores/LoadedMap';
-	import { storeSVGForPan, applyPanZoom } from '$lib/utils/applyPanZoom';
+	import { applyPanZoom } from '$lib/utils/applyPanZoom';
 	import { loadRegionsForApp } from '$lib/utils/loadRegions';
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
@@ -37,8 +37,10 @@
 	let isLoaded = false;
 
 	function setupMap(node: HTMLDivElement) {
-		storeSVGForPan(node);
-		applyPanZoom();
+		const svg = node.querySelector<SVGElement>('svg');
+		if (svg !== null) {
+			applyPanZoom(svg);
+		}
 		loadRegionsForApp(node);
 		isLoaded = true;
 	}

--- a/apps/yapms/src/routes/app/imported/+page.svelte
+++ b/apps/yapms/src/routes/app/imported/+page.svelte
@@ -3,7 +3,7 @@
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 	import { get } from 'svelte/store';
 	import { MapInsetsStore } from '$lib/stores/MapInsetsStore';
-	import applyPanZoom from '$lib/utils/applyPanZoom';
+	import { storeSVGForPan, applyPanZoom } from '$lib/utils/applyPanZoom';
 	import { loadRegionsForApp } from '$lib/utils/loadRegions';
 
 	const svg = get(ImportedSVGStore);
@@ -12,7 +12,8 @@
 	}
 
 	function setupMap(node: HTMLDivElement) {
-		applyPanZoom(node);
+		storeSVGForPan(node);
+		applyPanZoom();
 		loadRegionsForApp(node);
 	}
 </script>

--- a/apps/yapms/src/routes/app/imported/+page.svelte
+++ b/apps/yapms/src/routes/app/imported/+page.svelte
@@ -3,7 +3,7 @@
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 	import { get } from 'svelte/store';
 	import { MapInsetsStore } from '$lib/stores/MapInsetsStore';
-	import { storeSVGForPan, applyPanZoom } from '$lib/utils/applyPanZoom';
+	import { applyPanZoom } from '$lib/utils/applyPanZoom';
 	import { loadRegionsForApp } from '$lib/utils/loadRegions';
 
 	const svg = get(ImportedSVGStore);
@@ -12,8 +12,10 @@
 	}
 
 	function setupMap(node: HTMLDivElement) {
-		storeSVGForPan(node);
-		applyPanZoom();
+		const svg = node.querySelector<SVGElement>('svg');
+		if (svg !== null) {
+			applyPanZoom(svg);
+		}
 		loadRegionsForApp(node);
 	}
 </script>


### PR DESCRIPTION
This PR adds logic to reapply panzoom and reapplies panzoom when chart options are changed.

Summary of Code Changes
- Moves svg & panzoomInstance variables from function scope to file scope. Changes applyPanZoom to accommodate
- Creates new function storeSVGForPan to set the SVG that panzoom should be applied to.
- Creates reapplyPanZoom to dispose of current panZoom instance and create a new one
  - applyPanZoom is wrapped in a setTimeout in order to make sure the DOM updates before it runs.
- Calls reapplyPanZoom when chart options are changed

Fixes #46 