### PR TITLE
Lowercase f in shortcut

### DIFF
--- a/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
@@ -2,7 +2,7 @@
 <div class="flex flex-col gap-4 p-2">
 	<div class="flex justify-center items-center gap-2">
 		<span>Hold</span>
-		<kbd class="kbd">F</kbd>
+		<kbd class="kbd">f</kbd>
 		<span>to quickly fill in regions</span>
 	</div>
 	<div class="flex justify-center items-center gap-2">


### PR DESCRIPTION
The f shortcut should show as a lowercase in the shortcut description.