### PR TITLE
Remove cache on build command

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,16 +5,14 @@
       "cache": false
     },
     "build": {
+      "cache": false
     },
     "start": {
       "cache": false
     },
-    "check": {
-    },
-    "lint-no-warnings": {
-    },
-    "lint": {
-    },
+    "check": {},
+    "lint-no-warnings": {},
+    "lint": {},
     "format": {
       "cache": false
     }


### PR DESCRIPTION
The cache should be removed on the build command, because it's possible to delete the build without changing any source code.