### PR TITLE
Better modal interactivity

### DIFF
--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -4,7 +4,7 @@
 
 	export let title: string;
 
-	export let store: Writable<{ open: boolean }> | undefined;
+	export let store: Writable<{ open: boolean }>;
 	export let onClose: (() => void) | undefined = undefined;
 
 	export function close() {
@@ -16,13 +16,13 @@
 	}
 
 	let content: HTMLDivElement | undefined;
-	let offsetHeight: number;
-	let dialog: HTMLDialogElement;
+	let offsetHeight: number | undefined;
+	let dialog: HTMLDialogElement | undefined;
 
-	$: isOverflow = offsetHeight < (content?.scrollHeight ?? 0);
+	$: isOverflow = offsetHeight && offsetHeight < (content?.scrollHeight ?? 0);
 
-	$: if ($store?.open) dialog?.showModal();
-	$: if (!$store?.open) dialog?.close();
+	$: if ($store.open) dialog?.showModal();
+	$: if (!$store.open) dialog?.close();
 </script>
 
 <dialog class="modal modal-bottom lg:modal-middle" bind:this={dialog} on:close={close}>

--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -23,7 +23,6 @@
 
 	$: if ($store?.open) dialog?.showModal();
 	$: if (!$store?.open) dialog?.close();
-
 </script>
 
 <dialog class="modal modal-bottom lg:modal-middle" bind:this={dialog} on:close={close}>

--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -2,7 +2,6 @@
 	import XMark from '$lib/icons/XMark.svelte';
 	import type { Writable } from 'svelte/store';
 
-	export let open: boolean | undefined = undefined;
 	export let title: string;
 
 	export let store: Writable<{ open: boolean }> | undefined;
@@ -14,18 +13,20 @@
 		} else if ($store !== undefined) {
 			$store.open = false;
 		}
-		console.log(open);
 	}
 
 	let content: HTMLDivElement | undefined;
 	let offsetHeight: number;
+	let dialog: HTMLDialogElement;
 
 	$: isOverflow = offsetHeight < (content?.scrollHeight ?? 0);
+
+	$: if ($store?.open) dialog?.showModal();
+	$: if (!$store?.open) dialog?.close();
+
 </script>
 
-<input type="checkbox" class="modal-toggle" checked={$store?.open ?? false} />
-
-<dialog class="modal modal-bottom lg:modal-middle">
+<dialog class="modal modal-bottom lg:modal-middle" bind:this={dialog} on:close={close}>
 	<div class="modal-box flex flex-col w-full">
 		<div class="mb-6">
 			<div class="flex gap-x-2 align-middle">
@@ -55,4 +56,7 @@
 			<slot name="action" />
 		</div>
 	</div>
+	<form method="dialog" class="modal-backdrop">
+		<button on:click={close}>close</button>
+	</form>
 </dialog>


### PR DESCRIPTION
This PR changes modals to take advantage of the accessibility improvements of the dialog component (better focusing for screen readers, can close by clicking outside, can close using escape key)

Summary of Code Changes:
- Removes open property & checkbox
- binds dialog element to dialog variable, calls showModal and close on it when the open variable in store changes
- Adds an event listener to call close function when modal is closed by pressing escape
- Adds a modal-backdrop form with a button inside to handle clicking outside.