### PR TITLE
Two-Way battle chart ordering fix

### DIFF
--- a/apps/yapms/src/lib/components/chartbar/battlechart/BattleChart.svelte
+++ b/apps/yapms/src/lib/components/chartbar/battlechart/BattleChart.svelte
@@ -23,10 +23,10 @@
 						count: $CandidateCounts.get($TossupCandidateStore.id) ?? 0,
 						color: $TossupCandidateStore.margins.at(0)?.color ?? '#000000'
 					},
-					...($CandidatesStore.at(1)?.margins.map((_margin, index) => ({
+					...($CandidatesStore.at(1)?.margins.map((_margin, index, margins) => ({
 						name: $CandidatesStore.at(1)?.name ?? '',
-						count: $CandidateCountsMargins.get($CandidatesStore.at(1)?.id ?? '')?.at(index) ?? 0,
-						color: $CandidatesStore.at(1)?.margins.at(index)?.color ?? '#000000'
+						count: $CandidateCountsMargins.get($CandidatesStore.at(1)?.id ?? '')?.at(margins.length - index - 1) ?? 0,
+						color: $CandidatesStore.at(1)?.margins.at(margins.length - index - 1)?.color ?? '#000000'
 					})) ?? [])
 			  ]
 			: [


### PR DESCRIPTION
This PR fixes an issue where the battle chart margins wouldn't be aligned to the middle on a two-way chart.

After changes:
![image](https://github.com/yapms/yapms/assets/42476312/d785fe4e-49a8-4ae7-afd6-7c219788ff86)

Summary of Code Changes:
- Reverses the way in which CandidateCountsMargins and CandidatesStore elements are accessed in the battle chart