### PR TITLE
Fix Blurry Map on iOS

### DIFF
--- a/apps/yapms/src/lib/components/navbar/NavBar.svelte
+++ b/apps/yapms/src/lib/components/navbar/NavBar.svelte
@@ -66,7 +66,7 @@
 </script>
 
 <div
-	class="navbar flex-row bg-base-200 gap-3 overflow-x-scroll overflow-y-clip lg:overflow-x-clip min-h-0"
+	class="navbar flex-row bg-base-200 gap-3 overflow-x-auto overflow-y-clip min-h-0 z-10"
 >
 	<a href="/" class="btn btn-sm">home</a>
 	<button class="btn btn-sm btn-error" on:click={openClearMapModal}>clear</button>

--- a/apps/yapms/src/lib/components/navbar/NavBar.svelte
+++ b/apps/yapms/src/lib/components/navbar/NavBar.svelte
@@ -65,9 +65,7 @@
 	}
 </script>
 
-<div
-	class="navbar flex-row bg-base-200 gap-3 overflow-x-auto overflow-y-clip min-h-0 z-10"
->
+<div class="navbar flex-row bg-base-200 gap-3 overflow-x-auto overflow-y-clip min-h-0 z-10">
 	<a href="/" class="btn btn-sm">home</a>
 	<button class="btn btn-sm btn-error" on:click={openClearMapModal}>clear</button>
 	<button class="btn btn-sm" on:click={openCandidateModal}>candidates</button>


### PR DESCRIPTION
This PR fixes the map on iOS being blurry when you zoom in. It does this by setting a z-index value for the navbar. lg:overflow-x-clip is also removed and I changed overflow-x-scroll to overflow-x-auto which will allow you to scroll still. Tested on Lambdatest & an Iphone SE (2020)

Closes #261 
#316 is also no longer needed.