### PR TITLE
Pinch to zoom caused entire page to zoom

### DIFF
--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -28,7 +28,10 @@ function applyPanZoom(svg: SVGElement) {
 		autocenter: true,
 		zoomDoubleClickSpeed: 1,
 		smoothScroll: false,
-		onTouch: function () {
+		onTouch: (event) => {
+			if (event.touches.length >= 2) {
+				event.preventDefault();
+			}
 			return false;
 		}
 	});


### PR DESCRIPTION
At least on my iPod, pinch to zoom caused the entire webpage to zoom in. This should prevent it.