### PR TITLE
Stripes for split states

### DIFF
--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
@@ -87,9 +87,11 @@
 		//Update candidate object in region store
 		const newRegions = get(RegionsStore);
 		newRegions.forEach((region) => {
-			if (region.candidates[0].candidate.id === id) {
-				//Limit it to objects where candidate object present
-				region.candidates[0].candidate = $CandidatesStore[candidateIndex];
+			for (const candidate of region.candidates) {
+				if (candidate.candidate.id === id) {
+					//Limit it to objects where candidate object present
+					candidate.candidate = $CandidatesStore[candidateIndex];
+				}
 			}
 		});
 		$RegionsStore = newRegions;

--- a/apps/yapms/src/lib/stores/regions/Regions.ts
+++ b/apps/yapms/src/lib/stores/regions/Regions.ts
@@ -1,5 +1,5 @@
 import type Region from '$lib/types/Region';
-import { blendHexForLuma, calculateLumaHEX } from '$lib/utils/luma';
+import { blendHexColors, calculateLumaHEX } from '$lib/utils/luma';
 import { derived, writable, get } from 'svelte/store';
 import { TossupCandidateStore, CandidatesStore } from '../Candidates';
 import { ModeStore } from '../Mode';
@@ -74,7 +74,7 @@ RegionsStore.subscribe((regions) => {
 		} else {
 			fill = makePattern(winners);
 			const colors = winners.map((winner) => winner.candidate.margins[0].color);
-			lumaColor = `#${blendHexForLuma(colors)}`;
+			lumaColor = blendHexColors(colors);
 		}
 
 		region.nodes.region.style.fill = fill;

--- a/apps/yapms/src/lib/types/Region.ts
+++ b/apps/yapms/src/lib/types/Region.ts
@@ -24,6 +24,12 @@ export const RegionSchema = z.object({
 	})
 });
 
+export const RegionCandidateSchema = z.object({
+	candidate: CandidateSchema,
+	count: z.number(),
+	margin: z.number()
+});
+
 export const SavedRegionSchema = RegionSchema.omit({
 	shortName: true,
 	longName: true,
@@ -39,7 +45,7 @@ export const SavedRegionSchema = RegionSchema.omit({
 		.array()
 });
 
-export const RegionCandidatesSchema = z
+export const SavedRegionCandidatesSchema = z
 	.object({
 		candidate: z.string(),
 		count: z.number().nonnegative(),
@@ -49,6 +55,8 @@ export const RegionCandidatesSchema = z
 
 type Region = z.infer<typeof RegionSchema>;
 
-export type RegionCandidates = z.infer<typeof RegionCandidatesSchema>;
+export type RegionCandidate = z.infer<typeof RegionCandidateSchema>;
+
+export type SavedRegionCandidates = z.infer<typeof SavedRegionCandidatesSchema>;
 
 export default Region;

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -9,7 +9,7 @@ import { CandidatesStore, TossupCandidateStore } from '$lib/stores/Candidates';
 import { RegionsStore } from '$lib/stores/regions/Regions';
 import { saveAs } from 'file-saver';
 import DOMPurify from 'dompurify';
-import type { RegionCandidates } from '$lib/types/Region';
+import type { SavedRegionCandidates } from '$lib/types/Region';
 
 //This config allows all attributes used by the app to pass through DOMPurify without change.
 //If you are adding an attribute imported maps might need, add it here.
@@ -109,7 +109,7 @@ function exportImportAsSVG(): void {
 		svg.setAttribute('candidates', JSON.stringify(get(CandidatesStore)));
 		svg.setAttribute('tossup-candidate', JSON.stringify(get(TossupCandidateStore)));
 		for (const region of regions) {
-			const candidateAttr: RegionCandidates = [];
+			const candidateAttr: SavedRegionCandidates = [];
 			region.candidates.forEach((elem) => {
 				candidateAttr.push({
 					...elem,

--- a/apps/yapms/src/lib/utils/loadRegions.ts
+++ b/apps/yapms/src/lib/utils/loadRegions.ts
@@ -18,7 +18,7 @@ import { OriginalSourceStore } from '$lib/stores/OriginalSource';
 import type Region from '$lib/types/Region';
 import { ModeSchema } from '$lib/types/Mode';
 import { CandidateSchema } from '$lib/types/Candidate';
-import { RegionCandidatesSchema } from '$lib/types/Region';
+import { SavedRegionCandidatesSchema } from '$lib/types/Region';
 import { z } from 'zod';
 
 function createDefaultModeStore(node: HTMLDivElement) {
@@ -76,10 +76,10 @@ function findCandidate(id: string) {
 
 function getCandidatesForRegion(candidateStr: string, value: number) {
 	try {
-		const RegionCandidates = RegionCandidatesSchema.parse(JSON.parse(candidateStr));
+		const SavedRegionCandidates = SavedRegionCandidatesSchema.parse(JSON.parse(candidateStr));
 		let totCount = 0;
 		const candidateArr = [];
-		RegionCandidates.forEach((candidate) => {
+		SavedRegionCandidates.forEach((candidate) => {
 			totCount += candidate.count;
 			candidateArr.push({
 				...candidate,

--- a/apps/yapms/src/lib/utils/luma.ts
+++ b/apps/yapms/src/lib/utils/luma.ts
@@ -6,7 +6,7 @@ function hexToRGB(hex: string) {
 	return { r, g, b };
 }
 
-function blendHexForLuma(hexes: string[]) {
+function blendHexColors(hexes: string[]) {
 	let rCombined = 0,
 		gCombined = 0,
 		bCombined = 0;
@@ -22,7 +22,7 @@ function blendHexForLuma(hexes: string[]) {
 	rCombined = Math.floor(rCombined);
 	gCombined = Math.floor(gCombined);
 	bCombined = Math.floor(bCombined);
-	return rCombined.toString(16) + gCombined.toString(16) + bCombined.toString(16);
+	return '#' + rCombined.toString(16) + gCombined.toString(16) + bCombined.toString(16);
 }
 
 function calculateLumaRGB(r: number, g: number, b: number): number {
@@ -35,4 +35,4 @@ function calculateLumaHEX(hex: string): number {
 	return result;
 }
 
-export { blendHexForLuma, calculateLumaHEX, calculateLumaRGB };
+export { blendHexColors, calculateLumaHEX, calculateLumaRGB };

--- a/apps/yapms/src/lib/utils/luma.ts
+++ b/apps/yapms/src/lib/utils/luma.ts
@@ -6,6 +6,25 @@ function hexToRGB(hex: string) {
 	return { r, g, b };
 }
 
+function blendHexForLuma(hexes: string[]) {
+	let rCombined = 0,
+		gCombined = 0,
+		bCombined = 0;
+	for (const hex of hexes) {
+		const { r, g, b } = hexToRGB(hex);
+		rCombined += r;
+		gCombined += g;
+		bCombined += b;
+	}
+	rCombined /= hexes.length;
+	gCombined /= hexes.length;
+	bCombined /= hexes.length;
+	rCombined = Math.floor(rCombined);
+	gCombined = Math.floor(gCombined);
+	bCombined = Math.floor(bCombined);
+	return rCombined.toString(16) + gCombined.toString(16) + bCombined.toString(16);
+}
+
 function calculateLumaRGB(r: number, g: number, b: number): number {
 	return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
 }
@@ -16,4 +35,4 @@ function calculateLumaHEX(hex: string): number {
 	return result;
 }
 
-export { calculateLumaHEX, calculateLumaRGB };
+export { blendHexForLuma, calculateLumaHEX, calculateLumaRGB };

--- a/apps/yapms/src/lib/utils/patterns.ts
+++ b/apps/yapms/src/lib/utils/patterns.ts
@@ -11,14 +11,14 @@ export function removeAllPatterns() {
 	}
 }
 
-export function makePattern(winners: Array<RegionCandidate>) {
+export function makePattern(candidates: Array<RegionCandidate>) {
 	const pattern = document.createElementNS('http://www.w3.org/2000/svg', 'pattern');
 	pattern.setAttribute('patternUnits', 'userSpaceOnUse');
-	pattern.setAttribute('width', `${10 * winners.length}`);
+	pattern.setAttribute('width', `${10 * candidates.length}`);
 	pattern.setAttribute('height', '10');
 	pattern.setAttribute('patternTransform', 'rotate(45)');
 	let name = 'repeat';
-	winners.forEach((winner, i: number) => {
+	candidates.forEach((winner, i: number) => {
 		const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
 		line.setAttribute('stroke', winner.candidate.margins[0].color);
 		line.setAttribute('x1', `${5 + 10 * i}`);

--- a/apps/yapms/src/lib/utils/patterns.ts
+++ b/apps/yapms/src/lib/utils/patterns.ts
@@ -1,0 +1,36 @@
+import { browser } from '$app/environment';
+import type { RegionCandidate } from '$lib/types/Region';
+
+export function removeAllPatterns() {
+	if (browser) {
+		const patterns = document
+			?.getElementById('map-div')
+			?.querySelector('svg')
+			?.querySelectorAll('pattern');
+		patterns?.forEach((pattern) => pattern.remove());
+	}
+}
+
+export function makePattern(winners: Array<RegionCandidate>) {
+	const pattern = document.createElementNS('http://www.w3.org/2000/svg', 'pattern');
+	pattern.setAttribute('patternUnits', 'userSpaceOnUse');
+	pattern.setAttribute('width', `${10 * winners.length}`);
+	pattern.setAttribute('height', '10');
+	pattern.setAttribute('patternTransform', 'rotate(45)');
+	let name = 'repeat';
+	winners.forEach((winner, i: number) => {
+		const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+		line.setAttribute('stroke', winner.candidate.margins[0].color);
+		line.setAttribute('x1', `${5 + 10 * i}`);
+		line.setAttribute('x2', `${5 + 10 * i}`);
+		line.setAttribute('y1', '0');
+		line.setAttribute('y2', '10');
+		line.setAttribute('stroke-width', `10`);
+		pattern.appendChild(line);
+		name += `-${winner.candidate.id}`;
+	});
+	pattern.setAttribute('id', name);
+	const mapSVG = document?.getElementById('map-div')?.querySelector('svg');
+	mapSVG?.appendChild(pattern);
+	return `url(#${name})`;
+}


### PR DESCRIPTION
This PR changes equally split states to have their fill be a striped pattern rather than a single color. Works with any number of candidates.
![image](https://github.com/yapms/yapms/assets/42476312/fd97e05c-56c6-4677-82e5-1d0a447b95ea)

I have to rely on some DOM manipulation of the SVG here because patterns can only be defined within SVG. It is annoying.

Summary of Code Changes
- Modifies Regions.ts to identify if multiple winners present, if so, set fill to pattern, if not, set fill to winner color.
- Adds type named "RegionCandidate" for the structure contained within the candidate property of a region. 
- Renames  "RegionCandidates" type and corresponding schema to "SavedRegionCandidates" 
perhaps we ought to refactor so those can use the same type. was out of scope of this PR.
- Adds blendHexForLuma function which takes in an array of hex codes and returns their blended color. For striped states, this is then passed to luma to get black or white text.
- Adds function removeAllPatterns to remove all patterns when regions is updated. This is done to avoid duplicate versions of a pattern for the same two candidates.
- Adds function makePattern to create a stripe pattern for the candidates passed to it, add that pattern to the DOM, and then return the pattern name for use in fill.
- Fixes an issue where not all candidate objects would be properly edited within regions when candidates were edited.

Also, if this PR never gets merged in I won't mind. I was going to let this feature die, but people keep asking about it, so I finished it. I don't particularly like the code here (I look forward to what you think of for improving it), but it gets the job done.

A potential enhancement in the future could be to toggle this on/off. I chose not to implement it here because it requires that I would force a re-render of regions, and I couldn't get that to work reliably under a store.subscribe.