### PR TITLE
Region tooltip

### DIFF
--- a/apps/yapms/package.json
+++ b/apps/yapms/package.json
@@ -18,6 +18,7 @@
 		"format": "prettier --plugin prettier-plugin-svelte --write ."
 	},
 	"devDependencies": {
+		"@floating-ui/dom": "^1.5.1",
 		"@fontsource/roboto": "^5.0.8",
 		"@fortawesome/free-brands-svg-icons": "^6.4.2",
 		"@fortawesome/free-solid-svg-icons": "^6.4.2",

--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -8,6 +8,7 @@
 	import { LogoStore } from '$lib/stores/Logo';
 	import RedEaglePolitics from '$lib/assets/logos/rep.png';
 	import LetsTalkElections from '$lib/assets/logos/lte.png';
+	import { RegionTooltipStore } from '$lib/stores/RegionTooltip';
 
 	const chartTypeValues = ['pie', 'battle', 'none'];
 	const chartPositionValues = ['bottom', 'left'];
@@ -73,6 +74,12 @@
 					<label class="label cursor-pointer justify-start gap-3">
 						<input type="checkbox" class="toggle" bind:checked={$ChartLeansStore.enabled} />
 						<span class="label-text">Chart Tilts</span>
+					</label>
+				</div>
+				<div class="form-control w-full">
+					<label class="label cursor-pointer justify-start gap-3">
+						<input type="checkbox" class="toggle" bind:checked={$RegionTooltipStore.enabled} />
+						<span class="label-text">Region Tooltip</span>
 					</label>
 				</div>
 			</div>

--- a/apps/yapms/src/lib/components/tooltips/RegionTooltip.svelte
+++ b/apps/yapms/src/lib/components/tooltips/RegionTooltip.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { RegionTooltipStore } from '$lib/stores/RegionTooltip';
+	import { computePosition, offset, flip, shift } from '@floating-ui/dom';
+
+	let tooltip: HTMLDivElement | undefined = undefined;
+	let top = 0;
+	let left = 0;
+
+	RegionTooltipStore.subscribe(() => {
+		const virtualEl = {
+			getBoundingClientRect() {
+				return {
+					width: 0,
+					height: 0,
+					x: $RegionTooltipStore.x,
+					y: $RegionTooltipStore.y,
+					left: $RegionTooltipStore.x,
+					right: $RegionTooltipStore.x,
+					top: $RegionTooltipStore.y,
+					bottom: $RegionTooltipStore.y
+				};
+			}
+		};
+
+		if (tooltip !== undefined) {
+			computePosition(virtualEl, tooltip, {
+				placement: 'right-start',
+				middleware: [offset(15), flip(), shift()]
+			}).then(({ x, y }) => {
+				top = y;
+				left = x;
+			});
+		}
+	});
+</script>
+
+{#if $RegionTooltipStore.enabled}
+	<div
+		bind:this={tooltip}
+		class="bg-base-200 rounded-md absolute px-2 py-1 select-none drop-shadow-md"
+		class:hidden={!$RegionTooltipStore.delayElapsed || !$RegionTooltipStore.inRegions}
+		style="top:{top}px; left:{left}px;"
+	>
+		<p class="text-sm">{$RegionTooltipStore.content}</p>
+	</div>
+{/if}

--- a/apps/yapms/src/lib/stores/RegionTooltip.ts
+++ b/apps/yapms/src/lib/stores/RegionTooltip.ts
@@ -1,0 +1,10 @@
+import { writable } from 'svelte/store';
+
+export const RegionTooltipStore = writable({
+	enabled: false,
+	inRegions: false,
+	delayElapsed: false,
+	content: '',
+	x: 0,
+	y: 0
+});

--- a/apps/yapms/src/lib/stores/regions/Regions.ts
+++ b/apps/yapms/src/lib/stores/regions/Regions.ts
@@ -158,6 +158,7 @@ export const CandidateCountsMargins = derived(RegionsStore, ($RegionStore) => {
 });
 
 export const setPointerEvents = (): void => {
+	let delayElapse: NodeJS.Timeout | undefined;
 	const regions = get(RegionsStore);
 	for (const region of regions) {
 		if (region.permaLocked) {
@@ -195,13 +196,13 @@ export const setPointerEvents = (): void => {
 					y: e.clientY
 				});
 
-				setTimeout(() => {
-					if (e.clientX === get(RegionTooltipStore).x) {
-						RegionTooltipStore.set({
-							...get(RegionTooltipStore),
-							delayElapsed: true
-						});
-					}
+				clearTimeout(delayElapse);
+
+				delayElapse = setTimeout(() => {
+					RegionTooltipStore.set({
+						...get(RegionTooltipStore),
+						delayElapsed: true
+					});
 				}, 400);
 			}
 

--- a/apps/yapms/src/lib/stores/regions/Regions.ts
+++ b/apps/yapms/src/lib/stores/regions/Regions.ts
@@ -6,6 +6,7 @@ import { ModeStore } from '../Mode';
 import { disableRegion, editRegion, fillRegion, lockRegion, splitRegion } from './regionActions';
 import { InteractionStore } from '../Interaction';
 import { makePattern, removeAllPatterns } from '$lib/utils/patterns';
+import { RegionTooltipStore } from '../RegionTooltip';
 
 /**
  * Stores the state of all regions.
@@ -184,11 +185,48 @@ export const setPointerEvents = (): void => {
 			}
 		};
 
-		region.nodes.region.onmousemove = () => {
+		region.nodes.region.onmousemove = (e: MouseEvent) => {
+			if (get(RegionTooltipStore).enabled) {
+				RegionTooltipStore.set({
+					...get(RegionTooltipStore),
+					delayElapsed: false,
+					content: region.shortName,
+					x: e.clientX,
+					y: e.clientY
+				});
+
+				setTimeout(() => {
+					if (e.clientX === get(RegionTooltipStore).x) {
+						RegionTooltipStore.set({
+							...get(RegionTooltipStore),
+							delayElapsed: true
+						});
+					}
+				}, 400);
+			}
+
 			const currentMode = get(ModeStore);
 			const currentInteractions = get(InteractionStore);
 			if (currentMode === 'fill' && currentInteractions.has('KeyF')) {
 				fillRegion(region.id, false);
+			}
+		};
+
+		region.nodes.region.onmouseleave = () => {
+			if (get(RegionTooltipStore).enabled) {
+				RegionTooltipStore.set({
+					...get(RegionTooltipStore),
+					inRegions: false
+				});
+			}
+		};
+
+		region.nodes.region.onmouseenter = () => {
+			if (get(RegionTooltipStore).enabled) {
+				RegionTooltipStore.set({
+					...get(RegionTooltipStore),
+					inRegions: true
+				});
 			}
 		};
 

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -27,6 +27,7 @@
 	import AddCustomColorModal from '$lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte';
 	import EditCustomColorModal from '$lib/components/modals/candidatemodal/customcolors/EditCustomColorModal.svelte';
 	import ThemeModal from '$lib/components/modals/thememodal/ThemeModal.svelte';
+	import RegionTooltip from '$lib/components/tooltips/RegionTooltip.svelte';
 
 	if (browser) {
 		const url = get(page).url;
@@ -103,3 +104,5 @@
 <ShareModal />
 
 <ImportModal />
+
+<RegionTooltip />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ importers:
 
   apps/yapms:
     specifiers:
+      '@floating-ui/dom': ^1.5.1
       '@fontsource/roboto': ^5.0.8
       '@fortawesome/free-brands-svg-icons': ^6.4.2
       '@fortawesome/free-solid-svg-icons': ^6.4.2
@@ -76,6 +77,7 @@ importers:
       vite: ^4.4.9
       zod: ^3.22.2
     devDependencies:
+      '@floating-ui/dom': 1.5.1
       '@fontsource/roboto': 5.0.8
       '@fortawesome/free-brands-svg-icons': 6.4.2
       '@fortawesome/free-solid-svg-icons': 6.4.2
@@ -899,6 +901,23 @@ packages:
   /@eslint/js/8.48.0:
     resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@floating-ui/core/1.4.1:
+    resolution: {integrity: sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==}
+    dependencies:
+      '@floating-ui/utils': 0.1.1
+    dev: true
+
+  /@floating-ui/dom/1.5.1:
+    resolution: {integrity: sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==}
+    dependencies:
+      '@floating-ui/core': 1.4.1
+      '@floating-ui/utils': 0.1.1
+    dev: true
+
+  /@floating-ui/utils/0.1.1:
+    resolution: {integrity: sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==}
     dev: true
 
   /@fontsource/roboto/5.0.8:


### PR DESCRIPTION
This PR adds a tooltip to display a regions short-name on hover. This starts off disabled but can be enabled in the options modal.
![image](https://github.com/yapms/yapms/assets/42476312/d6f88999-f935-4508-bed9-1bcfb8d92dfb)
![yapmsBasicTooltip](https://github.com/yapms/yapms/assets/42476312/50371586-771e-4398-8da9-8b96b14cc9ed)

Summary of Code Changes:
- Adds @floating-ui/dom dependency
- Adds option to toggle the tooltip
- Creates component for the tooltip
  - Position is determined by floating-ui, with the cursor position passed to RegionTooltipStore as input.
  - The tooltip shows under the condition that 400ms has passed w/o mouse movement & the cursor is on a region
- Adds RegionTooltipStore
- Adds mouse listeners to update RegionTooltipStore