### PR TITLE
Disable BattleChart transitions

### DIFF
--- a/apps/yapms/src/lib/components/charts/battlechart/BattleChart.svelte
+++ b/apps/yapms/src/lib/components/charts/battlechart/BattleChart.svelte
@@ -6,6 +6,8 @@
 	import { CandidateCounts, CandidateCountsMargins } from '$lib/stores/regions/Regions';
 	import BattleChartLabel from './BattleChartLabel.svelte';
 
+	export let transitions: boolean = true;
+
 	$: tossupCounts = {
 		count: $CandidateCounts.get($TossupCandidateStore.id) ?? 0,
 		color: $TossupCandidateStore.margins.at(0)?.color ?? '#000000'
@@ -82,7 +84,12 @@
 		class:h-16={$ChartPositionStore === 'bottom'}
 	>
 		{#each finalChartData as count, index}
-			<BattleChartLabel count={count.count} color={count.color} percentage={percentages[index]} />
+			<BattleChartLabel
+				count={count.count}
+				color={count.color}
+				percentage={percentages[index]}
+				{transitions}
+			/>
 		{/each}
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/charts/battlechart/BattleChartLabel.svelte
+++ b/apps/yapms/src/lib/components/charts/battlechart/BattleChartLabel.svelte
@@ -5,15 +5,19 @@
 	export let percentage: number;
 	export let color: string;
 
+	export let transitions: boolean = true;
+
 	$: fontColor = calculateLumaHEX(color) > 0.5 ? '#000000' : '#ffffff';
 </script>
 
 <div
 	class="
-  flex flex-col flex-grow
-  overflow-hidden text-xl
-  justify-center items-center
-  transition-all ease-linear duration-200"
+	  flex flex-col flex-grow
+	  overflow-hidden text-xl
+	  justify-center items-center"
+	class:transition-all={transitions}
+	class:ease-linear={transitions}
+	class:duration-200={transitions}
 	style="flex-basis: {percentage * 100}%; background-color: {color}; color: {fontColor}"
 >
 	<span>

--- a/apps/yapms/src/routes/view/+page.svelte
+++ b/apps/yapms/src/routes/view/+page.svelte
@@ -54,7 +54,7 @@
 			</div>
 			<div class="grow" />
 			<div>
-				<HorizontalBattleChart />
+				<HorizontalBattleChart transitions={true} />
 			</div>
 		</div>
 	{/await}


### PR DESCRIPTION
Sometimes the battlechart isn't properly rendered at screenshot time. This should disable any transitions and remove that issue.