### PR TITLE
Fix screenshots not properly capturing colors of candidates.

### DIFF
--- a/apps/yapms/src/lib/components/candidatebox/CandidateBox.svelte
+++ b/apps/yapms/src/lib/components/candidatebox/CandidateBox.svelte
@@ -7,8 +7,12 @@
 
 	export let candidate: Candidate;
 	export let selectable: boolean;
+	export let transitions = true;
 
 	$: selected = selectable && $SelectedCandidateStore.id === candidate.id;
+	$: textColor = calculateLumaHEX(candidate.margins[0].color) > 0.5 ? 'black' : 'white';
+	$: backgroundColor = candidate.margins[0].color;
+	$: transitionSpeed = transitions ? '150ms' : '0ms';
 
 	function updateSelectedCandidate() {
 		SelectedCandidateStore.set(candidate);
@@ -17,12 +21,12 @@
 
 <div class="btn-group p-0.5 pointer-events-auto">
 	<button
-		class="btn no-animation overflow-hidden p-0"
+		class="btn no-animation overflow-hidden p-0 transition-all"
 		class:btn-sm={selected}
 		class:btn-xs={!selected}
-		style:background-color={candidate.margins[0].color}
-		style:color={calculateLumaHEX(candidate.margins[0].color) > 0.5 ? 'black' : 'white'}
-		style="transition: all 0.25s"
+		style:transition-duration={transitionSpeed}
+		style:background-color={backgroundColor}
+		style:color={textColor}
 		on:click={updateSelectedCandidate}
 	>
 		<div class="flex flex-col gap-0">

--- a/apps/yapms/src/lib/components/candidatebox/CandidateBoxContainer.svelte
+++ b/apps/yapms/src/lib/components/candidatebox/CandidateBoxContainer.svelte
@@ -2,11 +2,12 @@
 	import CandidateBox from './CandidateBox.svelte';
 	import { TossupCandidateStore, CandidatesStore } from '$lib/stores/Candidates';
 	export let selectable = true;
+	export let transitions = true;
 </script>
 
 <div class="flex flex-row flex-wrap justify-center relative pointer-events-none gap-1 h-0 z-10">
-	<CandidateBox candidate={$TossupCandidateStore} {selectable} />
+	<CandidateBox candidate={$TossupCandidateStore} {selectable} {transitions} />
 	{#each $CandidatesStore as candidate}
-		<CandidateBox {candidate} {selectable} />
+		<CandidateBox {candidate} {selectable} {transitions} />
 	{/each}
 </div>

--- a/apps/yapms/src/routes/view/+page.svelte
+++ b/apps/yapms/src/routes/view/+page.svelte
@@ -47,7 +47,7 @@
 {#if map !== undefined}
 	{#await map then map}
 		<div class="flex flex-col h-full p-3">
-			<CandidateBoxContainer selectable={false} />
+			<CandidateBoxContainer selectable={false} transitions={false} />
 			<div class="grow" />
 			<div use:setupMap id="map-div" class="overflow-hidden">
 				{@html map.default}


### PR DESCRIPTION
Sometimes the color transitions for the candidates would not finish before the screenshot is taken. This removes the transition effects, so the colors are correct in the screenshot.