### PR TITLE
Side bar on mobile

### DIFF
--- a/apps/yapms/src/lib/components/navbar/NavBar.svelte
+++ b/apps/yapms/src/lib/components/navbar/NavBar.svelte
@@ -79,7 +79,7 @@
 		>{$PocketBaseStore.authStore.isValid ? 'account' : 'login'}</button
 	>
 	<div class="grow" />
-	<button class="btn btn-sm hidden md:flex" on:click={toggleSidebar}>
+	<button class="btn btn-sm" on:click={toggleSidebar}>
 		{#if $SideBarStore}
 			<ChevronDoubleRight class="w-6 h-6" />
 		{:else}

--- a/apps/yapms/src/lib/components/sidebar/SideBar.svelte
+++ b/apps/yapms/src/lib/components/sidebar/SideBar.svelte
@@ -18,7 +18,7 @@
 {#if $SideBarStore}
 	<div class="z-10 h-full flex absolute right-0 md:relative md:basis-3/12 max-w-lg">
 		<div class="divider divider-horizontal w-0 m-0 flex" />
-		<div class="overflow-y-auto bg-base-100 w-full">
+		<div class="overflow-y-auto bg-base-100 w-full px-4 md:px-0">
 			<div class="flex flex-wrap justify-center p-2">
 				<SocialLinkGrid />
 			</div>

--- a/apps/yapms/src/lib/components/sidebar/SideBar.svelte
+++ b/apps/yapms/src/lib/components/sidebar/SideBar.svelte
@@ -16,16 +16,18 @@
 </script>
 
 {#if $SideBarStore}
-	<div class="divider divider-horizontal w-0 m-0 hidden md:flex" />
-	<div class="basis-3/12 max-w-md hidden md:inline overflow-y-auto">
-		<div class="flex flex-wrap justify-center p-2">
-			<SocialLinkGrid />
+	<div class="z-10 h-full flex absolute right-0 md:relative md:basis-3/12 max-w-lg">
+		<div class="divider divider-horizontal w-0 m-0 flex" />
+		<div class="overflow-y-auto bg-base-100 w-full">
+			<div class="flex flex-wrap justify-center p-2">
+				<SocialLinkGrid />
+			</div>
+			<h1 class="text-xl text-center font-bold">{title}</h1>
+			<Shortcuts />
+			{#if $PocketBaseStore.authStore.isValid}
+				<SavedMaps />
+			{/if}
+			<Sources />
 		</div>
-		<h1 class="text-xl text-center font-bold">{title}</h1>
-		<Shortcuts />
-		{#if $PocketBaseStore.authStore.isValid}
-			<SavedMaps />
-		{/if}
-		<Sources />
 	</div>
 {/if}

--- a/apps/yapms/src/lib/stores/SideBar.ts
+++ b/apps/yapms/src/lib/stores/SideBar.ts
@@ -1,3 +1,3 @@
 import { writable } from 'svelte/store';
 
-export const SideBarStore = writable(true);
+export const SideBarStore = writable(false);

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -23,6 +23,8 @@
 	import EditCustomColorModal from '$lib/components/modals/candidatemodal/customcolors/EditCustomColorModal.svelte';
 	import ThemeModal from '$lib/components/modals/thememodal/ThemeModal.svelte';
 	import RegionTooltip from '$lib/components/tooltips/RegionTooltip.svelte';
+	import { browser } from '$app/environment';
+	import { SideBarStore } from '$lib/stores/SideBar';
 
 	function handleKeyDown(event: KeyboardEvent) {
 		$InteractionStore.set(event.code, true);
@@ -30,6 +32,12 @@
 
 	function handleKeyUp(event: KeyboardEvent) {
 		$InteractionStore.delete(event.code);
+	}
+
+	if (browser) {
+		if (innerWidth > 768) {
+			$SideBarStore = true;
+		}
 	}
 </script>
 


### PR DESCRIPTION
This PR adds support for the side bar to appear on mobile (starts minimized)

This is what it looks like on a Pixel 5 in DevTools:
![image](https://github.com/yapms/yapms/assets/42476312/bc3621b3-78a5-4578-9d21-d464a4ae8c9d)

If it doesn't need to (in this case there are no links), the side bar will not cover the whole screen:
![image](https://github.com/yapms/yapms/assets/42476312/3616da06-7db4-494c-94a0-57ea5ac88d1d)

Summary of code changes:
- Makes the side bar toggle button always appear
- Changes classes so that the side bar is positioned absolutely when screen width is less than md
- Changes default SideBarStore value to false
- Adds logic to change SideBarStore to true if screen width is greater than 768 (Tailwind's md breakpoint)