### PR TITLE
Border Size Slider

### DIFF
--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -10,7 +10,6 @@
 	import LetsTalkElections from '$lib/assets/logos/lte.png';
 	import { RegionTooltipStore } from '$lib/stores/RegionTooltip';
 	import { AutoStrokeMultiplierStore } from '$lib/stores/AutoStrokeMultiplierStore';
-	import { updateAutoStroke } from '$lib/utils/applyPanZoom';
 
 	const chartTypeValues = ['pie', 'battle', 'none'];
 	const chartPositionValues = ['bottom', 'left'];
@@ -96,7 +95,6 @@
 					max="5"
 					step="0.1"
 					bind:value={$AutoStrokeMultiplierStore}
-					on:change={updateAutoStroke}
 					class="range"
 				/>
 			</label>

--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -9,6 +9,8 @@
 	import RedEaglePolitics from '$lib/assets/logos/rep.png';
 	import LetsTalkElections from '$lib/assets/logos/lte.png';
 	import { RegionTooltipStore } from '$lib/stores/RegionTooltip';
+	import { AutoStrokeScaleStore } from '$lib/stores/AutoStrokeScaleStore';
+	import { updateAutoStroke } from '$lib/utils/applyPanZoom';
 
 	const chartTypeValues = ['pie', 'battle', 'none'];
 	const chartPositionValues = ['bottom', 'left'];
@@ -83,6 +85,21 @@
 					</label>
 				</div>
 			</div>
+			<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
+				<div class="flex w-full justify-between">
+					<span class="label-text">Border Width</span>
+					<span class="label-text">{($AutoStrokeScaleStore * 100).toFixed(0)}%</span>
+				</div>
+				<input
+					type="range"
+					min="0"
+					max="5"
+					step="0.1"
+					bind:value={$AutoStrokeScaleStore}
+					on:change={updateAutoStroke}
+					class="range"
+				/>
+			</label>
 		</div>
 	</div>
 </ModalBase>

--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -9,7 +9,7 @@
 	import RedEaglePolitics from '$lib/assets/logos/rep.png';
 	import LetsTalkElections from '$lib/assets/logos/lte.png';
 	import { RegionTooltipStore } from '$lib/stores/RegionTooltip';
-	import { AutoStrokeScaleStore } from '$lib/stores/AutoStrokeScaleStore';
+	import { AutoStrokeMultiplierStore } from '$lib/stores/AutoStrokeMultiplierStore';
 	import { updateAutoStroke } from '$lib/utils/applyPanZoom';
 
 	const chartTypeValues = ['pie', 'battle', 'none'];
@@ -88,14 +88,14 @@
 			<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
 				<div class="flex w-full justify-between">
 					<span class="label-text">Border Width</span>
-					<span class="label-text">{($AutoStrokeScaleStore * 100).toFixed(0)}%</span>
+					<span class="label-text">{($AutoStrokeMultiplierStore * 100).toFixed(0)}%</span>
 				</div>
 				<input
 					type="range"
 					min="0"
 					max="5"
 					step="0.1"
-					bind:value={$AutoStrokeScaleStore}
+					bind:value={$AutoStrokeMultiplierStore}
 					on:change={updateAutoStroke}
 					class="range"
 				/>

--- a/apps/yapms/src/lib/stores/AutoStrokeMultiplierStore.ts
+++ b/apps/yapms/src/lib/stores/AutoStrokeMultiplierStore.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const AutoStrokeMultiplierStore = writable<number>(1);

--- a/apps/yapms/src/lib/stores/AutoStrokeScaleStore.ts
+++ b/apps/yapms/src/lib/stores/AutoStrokeScaleStore.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const AutoStrokeScaleStore = writable<number>(1);

--- a/apps/yapms/src/lib/stores/AutoStrokeScaleStore.ts
+++ b/apps/yapms/src/lib/stores/AutoStrokeScaleStore.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const AutoStrokeScaleStore = writable<number>(1);

--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -1,4 +1,4 @@
-import { AutoStrokeScaleStore } from '$lib/stores/AutoStrokeScaleStore';
+import { AutoStrokeMultiplierStore } from '$lib/stores/AutoStrokeMultiplierStore';
 import { LockMapStore } from '$lib/stores/LockMap';
 import panzoom, { type PanZoom } from 'panzoom';
 import { get } from 'svelte/store';
@@ -107,7 +107,7 @@ function adjustStroke(scale: number) {
 	const newStroke = Math.min(autoStrokeSettings.initStroke / scale, autoStrokeSettings.upperStroke);
 	autoStrokeSettings.svg.style.setProperty(
 		'--auto-border-stroke-width',
-		`${newStroke * get(AutoStrokeScaleStore)}px`
+		`${newStroke * get(AutoStrokeMultiplierStore)}px`
 	);
 }
 

--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -93,13 +93,6 @@ function connectZoomAndStroke() {
 	});
 }
 
-function updateAutoStroke() {
-	const scale = panZoomSettings?.panzoom.getTransform().scale;
-	if (scale !== undefined) {
-		adjustStroke(scale);
-	}
-}
-
 function adjustStroke(scale: number) {
 	if (autoStrokeSettings === undefined) {
 		return;
@@ -111,4 +104,11 @@ function adjustStroke(scale: number) {
 	);
 }
 
-export { applyPanZoom, applyFastPanZoom, reapplyPanZoom, applyAutoStroke, updateAutoStroke };
+AutoStrokeMultiplierStore.subscribe(() => {
+	const scale = panZoomSettings?.panzoom.getTransform().scale;
+	if (scale !== undefined) {
+		adjustStroke(scale);
+	}
+});
+
+export { applyPanZoom, applyFastPanZoom, reapplyPanZoom, applyAutoStroke };

--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -1,3 +1,4 @@
+import { AutoStrokeScaleStore } from '$lib/stores/AutoStrokeScaleStore';
 import { LockMapStore } from '$lib/stores/LockMap';
 import panzoom, { type PanZoom } from 'panzoom';
 import { get } from 'svelte/store';
@@ -92,12 +93,22 @@ function connectZoomAndStroke() {
 	});
 }
 
+function updateAutoStroke() {
+	const scale = panZoomSettings?.panzoom.getTransform().scale;
+	if (scale !== undefined) {
+		adjustStroke(scale);
+	}
+}
+
 function adjustStroke(scale: number) {
 	if (autoStrokeSettings === undefined) {
 		return;
 	}
 	const newStroke = Math.min(autoStrokeSettings.initStroke / scale, autoStrokeSettings.upperStroke);
-	autoStrokeSettings.svg.style.setProperty('--auto-border-stroke-width', `${newStroke}px`);
+	autoStrokeSettings.svg.style.setProperty(
+		'--auto-border-stroke-width',
+		`${newStroke * get(AutoStrokeScaleStore)}px`
+	);
 }
 
-export { applyPanZoom, applyFastPanZoom, reapplyPanZoom, applyAutoStroke };
+export { applyPanZoom, applyFastPanZoom, reapplyPanZoom, applyAutoStroke, updateAutoStroke };


### PR DESCRIPTION
This PR adds a slider to control a multiplier for border size in the options menu
![image](https://github.com/yapms/yapms/assets/42476312/920a92b2-75d6-4df5-8e8f-0a73259e768f)

Summary of Code Changes:
- Adds input slider to OptionsModal
- Creates AutoStrokeMultiplierStore to store an int (default 1)
- Creates updateAutoStroke to force update the auto-border-stroke-width css property
- Changes auto border stroke width to be multiplied by AutoStrokeMultiplierStore value
