### PR TITLE
Remove Shortcuts on Small Screens

### DIFF
--- a/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
@@ -1,5 +1,5 @@
-<div class="divider">Shortcuts</div>
-<div class="flex flex-col gap-4 p-2">
+<div class="hidden sm:divider">Shortcuts</div>
+<div class="hidden sm:flex flex-col gap-4 p-2">
 	<div class="flex justify-center items-center gap-2">
 		<span>Hold</span>
 		<kbd class="kbd">f</kbd>


### PR DESCRIPTION
Smalls screens are probably mobile, so remove the keyboard shortcuts.