### PR TITLE
Fix search for a Windows server

### DIFF
--- a/apps/yapms/src/routes/+page.server.ts
+++ b/apps/yapms/src/routes/+page.server.ts
@@ -1,6 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { globSync } from 'glob';
 import fs from 'fs';
+import path from 'path';
 
 export const load: PageServerLoad = () => {
 	const files = globSync('./src/lib/assets/maps/**/*.svg');
@@ -13,7 +14,7 @@ export const load: PageServerLoad = () => {
 		if (title === undefined) {
 			continue;
 		}
-		const route = '/app/' + file.split('/').pop()?.split('.').at(0)?.replaceAll('-', '/');
+		const route = '/app/' + file.split(path.sep).pop()?.split('.').at(0)?.replaceAll('-', '/');
 		search.unshift({
 			title,
 			route


### PR DESCRIPTION
This PR fixes a problem where if you are running the server on Windows, the separator for paths will be wrong & as a result, you will get redirected to some bad path from search results.