### PR TITLE
Fix zooming on click for piechart

### DIFF
--- a/apps/yapms/src/lib/components/charts/piechart/PieChart.svelte
+++ b/apps/yapms/src/lib/components/charts/piechart/PieChart.svelte
@@ -108,8 +108,6 @@
 			}
 		});
 	});
-
-	afterUpdate(reapplyPanZoom);
 </script>
 
 <div

--- a/apps/yapms/src/lib/components/charts/piechart/PieChart.svelte
+++ b/apps/yapms/src/lib/components/charts/piechart/PieChart.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import { afterUpdate, onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import { Chart, registerables } from 'chart.js';
 	import { CandidatesStore, TossupCandidateStore } from '$lib/stores/Candidates';
 	import { CandidateCounts, CandidateCountsMargins } from '$lib/stores/regions/Regions';
 	import ChartDataLabels from 'chartjs-plugin-datalabels';
 	import { ChartPositionStore } from '$lib/stores/Chart';
-	import { reapplyPanZoom } from '$lib/utils/applyPanZoom';
 	import { ChartLeansStore } from '$lib/stores/ChartLeansStore';
 
 	let canvasBind: HTMLCanvasElement;


### PR DESCRIPTION
When using the pie chart and the user updates the map, the map would then center. This removes the recenter when the piechart gets rendered.