### PR TITLE
Remove minimum zoom level

### DIFF
--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -24,7 +24,6 @@ function applyPanZoom(svg: SVGElement) {
 		panZoomSettings.panzoom.dispose();
 	}
 	const panzoomInstance = panzoom(svg, {
-		minZoom: 0.5,
 		maxZoom: 100,
 		autocenter: true,
 		zoomDoubleClickSpeed: 1,


### PR DESCRIPTION
This PR fixes an issue where the min zoom level would be too high for some maps and you couldnt zoom out to fit the entire map on your screen. Now you can zoom out infinitely.