### PR TITLE
Open links in new tab

### DIFF
--- a/apps/yapms/src/lib/components/links/SocialLinkGrid.svelte
+++ b/apps/yapms/src/lib/components/links/SocialLinkGrid.svelte
@@ -23,7 +23,7 @@
 		<span class="loading loading-ring"></span>
 	{:then links}
 		{#each links as link}
-			<a class="btn btn-sm px-4 flex-nowrap flex-grow gap-2" href={link.URL}>
+			<a class="btn btn-sm px-4 flex-nowrap flex-grow gap-2" target="_blank" href={link.URL}>
 				<Fa icon={getIcon(link.faIcon)} />
 				<span>{link.label}</span>
 			</a>


### PR DESCRIPTION
Social links should open in a new tab, to not accidentally wipe peoples progress.