### PR TITLE
Ability to map imported region properties to GeoJSON properties

### DIFF
--- a/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
@@ -17,7 +17,7 @@
 	const shortNameTooltip = 'The "short name" is used as region tooltip.';
 	const longNameTooltip = 'The "long name" is shown when editing or splitting a region.';
 	const propertySettingsTooltip =
-		'If you are importing from a GeoJSON or Shapefile with properties, you can use those properties for the name or value of the regions in YAPms.';
+		'If you are importing from a GeoJSON file with properties, you can use those properties for the name or value of the regions in YAPms.';
 
 	const projectionOptions = [
 		{ label: 'Mercator', projectionFunction: geoMercator },

--- a/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
@@ -14,6 +14,10 @@
 
 	const customProjectionDefinitionTooltip =
 		'Projection definitions are used to describe different map projections. YAPms uses PROJ.4 definitions. You can find many of these on https://epsg.io/';
+	const shortNameTooltip = 'The "short name" is used as region tooltip.';
+	const longNameTooltip = 'The "long name" is shown when editing or splitting a region.';
+	const propertySettingsTooltip =
+		'If you are importing from a GeoJSON or Shapefile with properties, you can use those properties for the name or value of the regions in YAPms.';
 
 	const projectionOptions = [
 		{ label: 'Mercator', projectionFunction: geoMercator },
@@ -30,7 +34,7 @@
 <details class="collapse bg-base-200">
 	<summary class="collapse-title text-xl font-medium">Import Options</summary>
 	<div class="collapse-content">
-		<div class="flex flex-col gap-2">
+		<div class="flex flex-col gap-0">
 			<div class="form-control w-full">
 				<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
 					<span class="label-text">Map Projection</span>
@@ -58,6 +62,53 @@
 						/>
 					</label>
 				{/if}
+			</div>
+			<span class="divider m-2"></span>
+			<div class="flex gap-x-1">
+				Property Settings (Advanced)
+				<div class="tooltip" data-tip={propertySettingsTooltip}>
+					<QuestionMarkCircle class="w-5" />
+				</div>
+			</div>
+			<div class="form-control w-full">
+				<label class="label flex-col cursor-pointer items-start justify-start">
+					<div class="flex gap-x-1 mb-2">
+						<span class="label-text">Short Name</span>
+						<div class="tooltip tooltip-right before:max-w-[12rem]" data-tip={shortNameTooltip}>
+							<QuestionMarkCircle class="w-5" />
+						</div>
+					</div>
+					<input
+						type="text"
+						class="input input-bordered w-full"
+						bind:value={$ImportedSVGStore.options.shortNameProp}
+					/>
+				</label>
+			</div>
+			<div class="form-control w-full">
+				<label class="label flex-col cursor-pointer items-start justify-start">
+					<div class="flex gap-x-1 mb-2">
+						<span class="label-text">Long Name</span>
+						<div class="tooltip tooltip-right before:max-w-[12rem]" data-tip={longNameTooltip}>
+							<QuestionMarkCircle class="w-5" />
+						</div>
+					</div>
+					<input
+						type="text"
+						class="input input-bordered w-full"
+						bind:value={$ImportedSVGStore.options.longNameProp}
+					/>
+				</label>
+			</div>
+			<div class="form-control w-full">
+				<label class="label flex-col cursor-pointer items-start justify-start">
+					<span class="label-text mb-2">Value</span>
+					<input
+						type="text"
+						class="input input-bordered w-full"
+						bind:value={$ImportedSVGStore.options.valueProp}
+					/>
+				</label>
 			</div>
 		</div>
 	</div>

--- a/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 	import QuestionMarkCircle from '$lib/icons/QuestionMarkCircle.svelte';
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 	import { proj4ToProjection } from '$lib/utils/importMap';
@@ -14,10 +15,11 @@
 
 	const customProjectionDefinitionTooltip =
 		'Projection definitions are used to describe different map projections. YAPms uses PROJ.4 definitions. You can find many of these on https://epsg.io/';
-	const shortNameTooltip = 'The "short name" is used as region tooltip.';
-	const longNameTooltip = 'The "long name" is shown when editing or splitting a region.';
 	const propertySettingsTooltip =
 		'If you are importing from a GeoJSON file with properties, you can use those properties for the name or value of the regions in YAPms.';
+	const shortNameTooltip = 'The "short name" is used as region tooltip.';
+	const longNameTooltip = 'The "long name" is shown when editing or splitting a region.';
+	const valueTooltip = 'Make sure to use a property that is a numeric value for this property.';
 
 	const projectionOptions = [
 		{ label: 'Mercator', projectionFunction: geoMercator },
@@ -102,7 +104,12 @@
 			</div>
 			<div class="form-control w-full">
 				<label class="label flex-col cursor-pointer items-start justify-start">
-					<span class="label-text mb-2">Value</span>
+					<div class="flex gap-x-1 mb-2">
+						<span class="label-text">Value</span>
+						<div class="tooltip tooltip-right before:max-w-[12rem]" data-tip={valueTooltip}>
+							<ExclamationCircle class="w-5" />
+						</div>
+					</div>
 					<input
 						type="text"
 						class="input input-bordered w-full"

--- a/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportOptions.svelte
@@ -67,7 +67,7 @@
 			</div>
 			<span class="divider m-2"></span>
 			<div class="flex gap-x-1">
-				Property Settings (Advanced)
+				GeoJSON Properties (Advanced)
 				<div class="tooltip" data-tip={propertySettingsTooltip}>
 					<QuestionMarkCircle class="w-5" />
 				</div>

--- a/apps/yapms/src/lib/stores/ImportedSVG.ts
+++ b/apps/yapms/src/lib/stores/ImportedSVG.ts
@@ -10,6 +10,9 @@ export const ImportedSVGStore = writable<ImportedSVG>({
 	content: '',
 	options: {
 		projectionFunction: geoMercator,
-		customProjectionDefinition: ''
+		customProjectionDefinition: '',
+		shortNameProp: '',
+		longNameProp: '',
+		valueProp: ''
 	}
 });

--- a/apps/yapms/src/lib/types/ImportedSVG.ts
+++ b/apps/yapms/src/lib/types/ImportedSVG.ts
@@ -6,5 +6,8 @@ export type ImportedSVG = {
 	options: {
 		projectionFunction: () => GeoProjection;
 		customProjectionDefinition: string;
+		shortNameProp: string;
+		longNameProp: string;
+		valueProp: string;
 	};
 };

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -87,9 +87,24 @@ function geoJsonToSVG(districtShapes: GeoJSON.FeatureCollection) {
 	const paths = districtShapes.features.map((feature: GeoJSON.Feature, i: number) => {
 		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 		path.setAttribute('region', i.toString());
-		path.setAttribute('short-name', i.toString());
-		path.setAttribute('long-name', i.toString());
-		path.setAttribute('value', '1');
+		path.setAttribute(
+			'short-name',
+			importOptions.shortNameProp !== '' && feature.properties
+				? feature.properties[importOptions.shortNameProp]
+				: i.toString()
+		);
+		path.setAttribute(
+			'long-name',
+			importOptions.shortNameProp !== '' && feature.properties
+				? feature.properties[importOptions.longNameProp]
+				: i.toString()
+		);
+		path.setAttribute(
+			'value',
+			importOptions.valueProp !== '' && feature.properties
+				? feature.properties[importOptions.valueProp]
+				: '1'
+		);
 		path.setAttribute('d', render(feature) ?? '');
 		return path;
 	});


### PR DESCRIPTION
This PR adds a few new settings to the import menu that allow you to specify properties in GeoJSON for import functionality to use when importing a map. This won't work with shapefiles.

this is quite in the weeds