### PR TITLE
Handle NaN on map load

### DIFF
--- a/apps/yapms/src/lib/utils/loadRegions.ts
+++ b/apps/yapms/src/lib/utils/loadRegions.ts
@@ -132,7 +132,10 @@ function createRegionStore(node: HTMLDivElement) {
 			}
 		}
 
-		const value = Number(childHTML.getAttribute('value'));
+		let value = Number(childHTML.getAttribute('value'));
+		if (isNaN(value)) {
+			value = 1;
+		}
 		const candidateString = childHTML.getAttribute('candidates');
 		const newRegion: Region = {
 			id: childHTML.getAttribute('region') ?? '',


### PR DESCRIPTION
If the map loader cannot parse a number it creates a NaN value, which the rest of the program cannot handle.