### PR TITLE
Remove Card Shadows

### DIFF
--- a/apps/yapms/src/lib/components/mapcard/MapCard.svelte
+++ b/apps/yapms/src/lib/components/mapcard/MapCard.svelte
@@ -20,7 +20,7 @@
 	}
 </script>
 
-<div class="card card-bordered w-80 md:w-92 h-48 lg:h-52 bg-base-100 shadow-xl image-full">
+<div class="card w-80 md:w-92 h-48 lg:h-52 bg-base-100 image-full">
 	{#await image then image}
 		<figure><img src={image.default} alt={name} /></figure>
 	{/await}


### PR DESCRIPTION
Card shadows were being cut off around the edges. Causing a harsh cutoff effect.
![image](https://github.com/yapms/yapms/assets/13600696/7c5d4557-0fac-4872-a569-11f416035a2f)

This removes the shadow so it's no longer an issue.