### PR TITLE
Horizontal Bar Chart

### DIFF
--- a/apps/yapms/src/lib/components/chartarea/ChartArea.svelte
+++ b/apps/yapms/src/lib/components/chartarea/ChartArea.svelte
@@ -3,6 +3,7 @@
 	import { LogoStore } from '$lib/stores/Logo';
 	import BattleChart from '../charts/battlechart/BattleChart.svelte';
 	import CircleChart from '../charts/circlechart/CircleChart.svelte';
+	import HorizontalBarChart from '../charts/horizontalbarchart/HorizontalBarChart.svelte';
 
 	let logoSize: { width: string | undefined; height: string | undefined } = {
 		width: '100%',
@@ -32,6 +33,8 @@
 >
 	{#if $ChartTypeStore === 'battle'}
 		<BattleChart />
+	{:else if $ChartTypeStore === 'horizontal Bar'}
+		<HorizontalBarChart />
 	{:else if $ChartTypeStore === 'pie'}
 		<CircleChart type="pie" />
 	{:else}

--- a/apps/yapms/src/lib/components/charts/horizontalbarchart/HorizontalBarChart.svelte
+++ b/apps/yapms/src/lib/components/charts/horizontalbarchart/HorizontalBarChart.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import { CandidatesStore, TossupCandidateStore } from '$lib/stores/Candidates';
+	import { ChartPositionStore } from '$lib/stores/Chart';
+	import { ChartLeansStore } from '$lib/stores/ChartLeansStore';
+	import { CandidateCounts, CandidateCountsMargins } from '$lib/stores/regions/Regions';
+	import BattleChartLabel from '../battlechart/BattleChartLabel.svelte';
+
+	export let transitions: boolean = true;
+
+	$: tossupCounts = {
+		name: $TossupCandidateStore.name,
+		total: $CandidateCounts.get($TossupCandidateStore.id) ?? 0,
+		counts: [
+			{
+				count: $CandidateCounts.get($TossupCandidateStore.id) ?? 0,
+				color: $TossupCandidateStore.margins.at(0)?.color ?? '#000000',
+				percentage: 1
+			}
+		]
+	};
+
+	$: candidatesWithLeans = $CandidatesStore.map((candidate) => {
+		return {
+			name: candidate.name,
+			total: $CandidateCounts.get(candidate.id) ?? 0,
+			counts: candidate.margins.map((margin, index) => ({
+				count: $CandidateCountsMargins.get(candidate.id)?.at(index) ?? 0,
+				color: margin.color,
+				percentage:
+					$CandidateCountsMargins.get(candidate.id)?.at(index) ??
+					0 / ($CandidateCounts.get(candidate.id) ?? 0)
+			}))
+		};
+	});
+
+	$: countsWithNoLeans = $CandidatesStore.map((candidate) => {
+		return {
+			name: candidate.name,
+			total: $CandidateCounts.get(candidate.id) ?? 0,
+			counts: [
+				{
+					count: $CandidateCounts.get(candidate.id) ?? 0,
+					color: candidate.margins[0].color,
+					percentage: 1
+				}
+			]
+		};
+	});
+
+	$: choosenChartData = $ChartLeansStore.enabled ? candidatesWithLeans : countsWithNoLeans;
+
+	$: finalChartData = [tossupCounts].concat(choosenChartData);
+
+	/**
+	 * Find the votes for the highest vote-getter
+	 */
+	$: maxCandidateTotal = finalChartData.reduce(
+		(max, candidate) => Math.max(max, candidate.total),
+		0
+	);
+
+	/**
+	 * Calculate the percentage of votes for each candidate in terms of the max total.
+	 */
+	$: percentages = finalChartData.map((candidate) => (candidate.total / maxCandidateTotal) * 100);
+
+	/**
+	 * Find the length of the longest-named candidate so all bars can start at the same point.
+	 */
+	$: maxCandidateNameLength = finalChartData.reduce(
+		(max, candidate) => Math.max(max, candidate.name.length),
+		0
+	);
+</script>
+
+<div
+	class="w-full items-center justify-center space-y-1 overflow-y-auto"
+	class:grid={$ChartPositionStore === 'bottom'}
+	class:h-full={$ChartPositionStore === 'bottom'}
+	class:h-fit={$ChartPositionStore === 'left'}
+	style="grid-template-columns: {maxCandidateNameLength + 1}ch calc(100% - {maxCandidateNameLength +
+		1}ch)"
+>
+	{#each finalChartData as candidate, index}
+		<p>{candidate.name}</p>
+		<div
+			class="flex flex-row transition-all ease-linear duration-200"
+			style="width:{percentages[index]}%"
+		>
+			{#each candidate.counts as count}
+				<BattleChartLabel
+					count={count.count}
+					color={count.color}
+					percentage={count.percentage}
+					{transitions}
+				/>
+			{/each}
+		</div>
+	{/each}
+</div>

--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -19,7 +19,7 @@
 
 	let logos = $PocketBaseStore.collection('creator_logos').getFullList();
 
-	const chartTypeValues = ['pie', 'doughnut', 'battle', 'none'];
+	const chartTypeValues = ['pie', 'doughnut', 'battle', 'horizontal Bar', 'none'];
 	const chartPositionValues = ['bottom', 'left'];
 
 	function readLogoFile() {

--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -13,6 +13,7 @@
 	import { FontColorStore } from '$lib/stores/FontColorStore';
 	import { PUBLIC_POCKETBASE_URI } from '$env/static/public';
 	import { RegionTextsStore } from '$lib/stores/RegionTextsStore';
+	import { RegionStrokeColorStore } from '$lib/stores/RegionStrokeColorStore';
 
 	let logoFile: FileList | undefined;
 	let logoFileInput: HTMLInputElement | undefined;
@@ -97,17 +98,31 @@
 				/>
 			</label>
 		</div>
-		<div class="form-control w-full">
-			<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
-				<span class="label-text">Font Color</span>
-				<select class="select select-bordered w-full capitalize" bind:value={$FontColorStore}>
-					<option value="auto">Auto</option>
-					<option value="white">White</option>
-					<option value="black">Black</option>
-				</select>
-			</label>
-		</div>
 		<div class="grid grid-cols-2">
+			<div class="form-control w-full">
+				<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
+					<span class="label-text">Font Color</span>
+					<select class="select select-bordered w-full capitalize" bind:value={$FontColorStore}>
+						<option value="auto">Auto</option>
+						<option value="white">White</option>
+						<option value="black">Black</option>
+					</select>
+				</label>
+			</div>
+			<div class="form-control w-full">
+				<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
+					<span class="label-text">Border Color</span>
+					<select
+						class="select select-bordered w-full capitalize"
+						bind:value={$RegionStrokeColorStore}
+					>
+						<option value="background">Background</option>
+						<option value="contrast">Contrasting</option>
+						<option value="white">White</option>
+						<option value="black">Black</option>
+					</select>
+				</label>
+			</div>
 			<div class="form-control w-full">
 				<label class="label cursor-pointer justify-start gap-3">
 					<input type="checkbox" class="toggle" bind:checked={$LockMapStore} />

--- a/apps/yapms/src/lib/stores/RegionStrokeColorStore.ts
+++ b/apps/yapms/src/lib/stores/RegionStrokeColorStore.ts
@@ -1,0 +1,37 @@
+import { get, writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export const RegionStrokeColorStore = writable<'background' | 'contrast' | 'white' | 'black'>(
+	'background'
+);
+
+const colorsByKey = {
+	background: 'oklch(var(--b1) / var(--tw-bg-opacity, 1))',
+	contrast: 'oklch(var(--bc) / var(--tw-bg-opacity, 1))',
+	white: '#ffffff',
+	black: '#000000'
+};
+
+if (browser) {
+	const strokeColor = localStorage.getItem('RegionStrokeColor');
+	if (
+		strokeColor === 'background' ||
+		strokeColor === 'contrast' ||
+		strokeColor === 'white' ||
+		strokeColor === 'black'
+	) {
+		RegionStrokeColorStore.set(strokeColor);
+	}
+	RegionStrokeColorStore.subscribe((value) => {
+		localStorage.setItem('RegionStrokeColor', value);
+		const mapSVG = document.getElementById('map-div')?.querySelector('svg');
+		if (mapSVG) {
+			mapSVG.style.setProperty('--region-stroke-color', colorsByKey[value]);
+		}
+	});
+}
+
+//This is here because map-div is not defined when the above code runs.
+export function setRegionStrokeColor(node: SVGElement) {
+	node.style.setProperty('--region-stroke-color', get(RegionStrokeColorStore));
+}

--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -31,11 +31,12 @@ body {
 
 #map-div > svg {
 	--auto-border-stroke-width: 0px;
+	--region-stroke-color: 'oklch(var(--b1) / var(--tw-bg-opacity, 1))';
 }
 
 [map-type='regions'] path {
 	stroke-width: var(--auto-border-stroke-width);
-	stroke: oklch(var(--b1) / var(--tw-bg-opacity, 1));
+	stroke: var(--region-stroke-color);
 }
 
 [map-type='inset-texts'] {

--- a/apps/yapms/src/lib/types/ChartType.ts
+++ b/apps/yapms/src/lib/types/ChartType.ts
@@ -1,1 +1,1 @@
-export type ChartType = 'battle' | 'pie' | 'doughnut' | 'none';
+export type ChartType = 'battle' | 'pie' | 'doughnut' | 'horizontal Bar' | 'none';

--- a/apps/yapms/src/routes/app/[country]/+layout.svelte
+++ b/apps/yapms/src/routes/app/[country]/+layout.svelte
@@ -11,6 +11,7 @@
 	import { loadMapIdentifier } from '$lib/stores/MapIdentifier';
 	import { loadActionGroups } from '$lib/stores/ActionGroups';
 	import { RegionTextsStore } from '$lib/stores/RegionTextsStore';
+	import { setRegionStrokeColor } from '$lib/stores/RegionStrokeColorStore';
 
 	$: requestedMap = $page.url.pathname.replace('/app/', '').replaceAll('/', '-');
 	$: country = requestedMap.split('-').at(0);
@@ -25,6 +26,7 @@
 		if (svg !== null) {
 			applyPanZoom(svg);
 			applyAutoStroke(svg);
+			setRegionStrokeColor(svg);
 			loadSidebarTitle(svg);
 			loadSidebarSources(svg);
 			loadMapIdentifier(svg);

--- a/apps/yapms/src/routes/app/imported/+page.svelte
+++ b/apps/yapms/src/routes/app/imported/+page.svelte
@@ -5,6 +5,7 @@
 	import { MapInsetsStore } from '$lib/stores/MapInsetsStore';
 	import { applyAutoStroke, applyPanZoom } from '$lib/utils/applyPanZoom';
 	import { loadRegionsForApp } from '$lib/utils/loadRegions';
+	import { setRegionStrokeColor } from '$lib/stores/RegionStrokeColorStore';
 
 	const svg = get(ImportedSVGStore);
 	if (!svg.loaded) {
@@ -16,6 +17,7 @@
 		if (svg !== null) {
 			applyPanZoom(svg);
 			applyAutoStroke(svg);
+			setRegionStrokeColor(svg);
 		}
 		loadRegionsForApp(node);
 	}


### PR DESCRIPTION
This PR adds the Horizontal Bar Chart from old YAPms. 

On the bottom:
![image](https://github.com/yapms/yapms/assets/42476312/7c34d729-0413-4dff-bf25-85a1dad11e39)
On the left:
![image](https://github.com/yapms/yapms/assets/42476312/59572d08-fbe8-4526-853f-ff2f6b08c7e5)

This line:
`style="grid-template-columns: {maxCandidateNameLength + 1}ch calc(100% - {maxCandidateNameLength +
		1}ch)"`
is particularly gross but I don't know of a better way to do it. Perhaps there is a good way with flex I don't know about to make sure the column for names is consistent size.

I tested this on both Firefox, Chrome and everything worked the same on both.