### PR TITLE
Remove Content-Disposition header

### DIFF
--- a/apps/pocketbase/main.go
+++ b/apps/pocketbase/main.go
@@ -30,7 +30,7 @@ func main() {
 	app.OnFileDownloadRequest().Add(func(e *core.FileDownloadEvent) error {
 		if e.FileField.Name == "data" {
 			e.HttpContext.Response().Header().Set("Content-Encoding", "gzip")
-			e.HttpContext.Response().Header().Set("Content-Disposition", "")
+			e.HttpContext.Response().Header().Set("Content-Disposition", "inline")
 		}
 		return nil
 	})

--- a/apps/pocketbase/main.go
+++ b/apps/pocketbase/main.go
@@ -30,6 +30,7 @@ func main() {
 	app.OnFileDownloadRequest().Add(func(e *core.FileDownloadEvent) error {
 		if e.FileField.Name == "data" {
 			e.HttpContext.Response().Header().Set("Content-Encoding", "gzip")
+			e.HttpContext.Response().Header().Set("Content-Disposition", "")
 		}
 		return nil
 	})


### PR DESCRIPTION
Safari (and iOS mobile browsers in general, it seems) have not been loading saved maps. This is because Safari was not properly decompressing the gzipped map data. [This issue](https://github.com/getsentry/self-hosted/issues/2285) suggested to remove the Content-Disposition header. I set it to empty and Safari worked.

Side note: I tried using the .Del function for the header instead of setting it to "" but that resulted in no change, either because the method doesn't work or (more likely imo), the header is set later in the process of sending the request if it is not already there.

Don't know why this started happening all of a sudden when we have presumably been sending this header forever.