### PR TITLE
Border Color Option

### DIFF
--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -112,7 +112,10 @@
 			<div class="form-control w-full">
 				<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
 					<span class="label-text">Border Color</span>
-					<select class="select select-bordered w-full capitalize" bind:value={$RegionStrokeColorStore}>
+					<select
+						class="select select-bordered w-full capitalize"
+						bind:value={$RegionStrokeColorStore}
+					>
 						<option value="background">Background</option>
 						<option value="contrast">Contrasting</option>
 						<option value="white">White</option>

--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -13,6 +13,7 @@
 	import { FontColorStore } from '$lib/stores/FontColorStore';
 	import { PUBLIC_POCKETBASE_URI } from '$env/static/public';
 	import { RegionTextsStore } from '$lib/stores/RegionTextsStore';
+	import { RegionStrokeColorStore } from '$lib/stores/RegionStrokeColorStore';
 
 	let logoFile: FileList | undefined;
 	let logoFileInput: HTMLInputElement | undefined;
@@ -97,17 +98,28 @@
 				/>
 			</label>
 		</div>
-		<div class="form-control w-full">
-			<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
-				<span class="label-text">Font Color</span>
-				<select class="select select-bordered w-full capitalize" bind:value={$FontColorStore}>
-					<option value="auto">Auto</option>
-					<option value="white">White</option>
-					<option value="black">Black</option>
-				</select>
-			</label>
-		</div>
 		<div class="grid grid-cols-2">
+			<div class="form-control w-full">
+				<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
+					<span class="label-text">Font Color</span>
+					<select class="select select-bordered w-full capitalize" bind:value={$FontColorStore}>
+						<option value="auto">Auto</option>
+						<option value="white">White</option>
+						<option value="black">Black</option>
+					</select>
+				</label>
+			</div>
+			<div class="form-control w-full">
+				<label class="label flex-col cursor-pointer items-start justify-start space-y-2">
+					<span class="label-text">Border Color</span>
+					<select class="select select-bordered w-full capitalize" bind:value={$RegionStrokeColorStore}>
+						<option value="background">Background</option>
+						<option value="contrast">Contrasting</option>
+						<option value="white">White</option>
+						<option value="black">Black</option>
+					</select>
+				</label>
+			</div>
 			<div class="form-control w-full">
 				<label class="label cursor-pointer justify-start gap-3">
 					<input type="checkbox" class="toggle" bind:checked={$LockMapStore} />

--- a/apps/yapms/src/lib/stores/RegionStrokeColorStore.ts
+++ b/apps/yapms/src/lib/stores/RegionStrokeColorStore.ts
@@ -33,5 +33,5 @@ if (browser) {
 
 //This exists because map-div/SVG is not defined when the above code runs.
 export function setRegionStrokeColor(node: SVGElement) {
-	node.style.setProperty('--region-stroke-color', get(RegionStrokeColorStore));
+	node.style.setProperty('--region-stroke-color', colorsByKey[get(RegionStrokeColorStore)]);
 }

--- a/apps/yapms/src/lib/stores/RegionStrokeColorStore.ts
+++ b/apps/yapms/src/lib/stores/RegionStrokeColorStore.ts
@@ -1,0 +1,37 @@
+import { get, writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export const RegionStrokeColorStore = writable<'background' | 'contrast' | 'white' | 'black'>(
+	'background'
+);
+
+const colorsByKey = {
+	background: 'oklch(var(--b1) / var(--tw-bg-opacity, 1))',
+	contrast: 'oklch(var(--bc) / var(--tw-bg-opacity, 1))',
+	white: '#ffffff',
+	black: '#000000'
+};
+
+if (browser) {
+	const strokeColor = localStorage.getItem('RegionStrokeColor');
+	if (
+		strokeColor === 'background' ||
+		strokeColor === 'contrast' ||
+		strokeColor === 'white' ||
+		strokeColor === 'black'
+	) {
+		RegionStrokeColorStore.set(strokeColor);
+	}
+	RegionStrokeColorStore.subscribe((value) => {
+		localStorage.setItem('RegionStrokeColor', value);
+		const mapSVG = document.getElementById('map-div')?.querySelector('svg');
+		if (mapSVG) {
+			mapSVG.style.setProperty('--region-stroke-color', colorsByKey[value]);
+		}
+	});
+}
+
+//This exists because map-div/SVG is not defined when the above code runs.
+export function setRegionStrokeColor(node: SVGElement) {
+	node.style.setProperty('--region-stroke-color', get(RegionStrokeColorStore));
+}

--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -31,11 +31,12 @@ body {
 
 #map-div > svg {
 	--auto-border-stroke-width: 0px;
+	--region-stroke-color: 'oklch(var(--b1) / var(--tw-bg-opacity, 1))';
 }
 
 [map-type='regions'] path {
 	stroke-width: var(--auto-border-stroke-width);
-	stroke: oklch(var(--b1) / var(--tw-bg-opacity, 1));
+	stroke: var(--region-stroke-color);
 }
 
 [map-type='inset-texts'] {

--- a/apps/yapms/src/routes/app/[country]/+layout.svelte
+++ b/apps/yapms/src/routes/app/[country]/+layout.svelte
@@ -11,6 +11,7 @@
 	import { loadMapIdentifier } from '$lib/stores/MapIdentifier';
 	import { loadActionGroups } from '$lib/stores/ActionGroups';
 	import { RegionTextsStore } from '$lib/stores/RegionTextsStore';
+	import { setRegionStrokeColor } from '$lib/stores/RegionStrokeColorStore';
 
 	$: requestedMap = $page.url.pathname.replace('/app/', '').replaceAll('/', '-');
 	$: country = requestedMap.split('-').at(0);
@@ -25,6 +26,7 @@
 		if (svg !== null) {
 			applyPanZoom(svg);
 			applyAutoStroke(svg);
+			setRegionStrokeColor(svg);
 			loadSidebarTitle(svg);
 			loadSidebarSources(svg);
 			loadMapIdentifier(svg);

--- a/apps/yapms/src/routes/app/imported/+page.svelte
+++ b/apps/yapms/src/routes/app/imported/+page.svelte
@@ -5,6 +5,7 @@
 	import { MapInsetsStore } from '$lib/stores/MapInsetsStore';
 	import { applyAutoStroke, applyPanZoom } from '$lib/utils/applyPanZoom';
 	import { loadRegionsForApp } from '$lib/utils/loadRegions';
+	import { setRegionStrokeColor } from '$lib/stores/RegionStrokeColorStore';
 
 	const svg = get(ImportedSVGStore);
 	if (!svg.loaded) {
@@ -16,6 +17,7 @@
 		if (svg !== null) {
 			applyPanZoom(svg);
 			applyAutoStroke(svg);
+			setRegionStrokeColor(svg);
 		}
 		loadRegionsForApp(node);
 	}


### PR DESCRIPTION
This PR creates a setting for changing the region border color to a couple different options. "Contrasting" makes use of the daisyUI color we use for insets. White and black are there as on some themes, the contrasting color is not that great.

I am not totally happy with calling another function on page load, but it's needed to define the CSS variable from cache. Setting the variable on document.body works without that function, but that seemed to be a worse approach imo.