### PR TITLE
Apply auto border to rects

### DIFF
--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -34,7 +34,7 @@ body {
 	--region-stroke-color: 'oklch(var(--b1) / var(--tw-bg-opacity, 1))';
 }
 
-[map-type='regions'] path {
+[map-type='regions'] path, rect {
 	stroke-width: var(--auto-border-stroke-width);
 	stroke: var(--region-stroke-color);
 }

--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -34,7 +34,8 @@ body {
 	--region-stroke-color: 'oklch(var(--b1) / var(--tw-bg-opacity, 1))';
 }
 
-[map-type='regions'] path, rect {
+[map-type='regions'] path,
+rect {
 	stroke-width: var(--auto-border-stroke-width);
 	stroke: var(--region-stroke-color);
 }


### PR DESCRIPTION
The new border color setting exposed that auto borders were not applying to the DC label. This is because it is specified as a rect, not a path, and the CSS rule doesn't target it. This PR fixes that.