### PR TITLE
Key combo to recenter map

### DIFF
--- a/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
@@ -38,8 +38,6 @@
 	</div>
 	<div class="flex justify-center items-center gap-2">
 		<span>Press</span>
-		<kbd class="kbd">shift</kbd>
-		+
 		<kbd class="kbd">r</kbd>
 		<span>to recenter map</span>
 	</div>

--- a/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
@@ -36,4 +36,11 @@
 		<kbd class="kbd">ctrl</kbd>
 		<span>to decrement colors</span>
 	</div>
+	<div class="flex justify-center items-center gap-2">
+		<span>Press</span>
+		<kbd class="kbd">shift</kbd>
+		+
+		<kbd class="kbd">r</kbd>
+		<span>to recenter map</span>
+	</div>
 </div>

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -29,6 +29,14 @@
 
 	function handleKeyDown(event: KeyboardEvent) {
 		$InteractionStore.set(event.code, true);
+		if (
+			event.shiftKey &&
+			event.code === 'KeyR' &&
+			event.target instanceof Element &&
+			event.target.id === 'map-div'
+		) {
+			reapplyPanZoom();
+		}
 	}
 
 	function handleKeyUp(event: KeyboardEvent) {

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -30,7 +30,6 @@
 	function handleKeyDown(event: KeyboardEvent) {
 		$InteractionStore.set(event.code, true);
 		if (
-			event.shiftKey &&
 			event.code === 'KeyR' &&
 			event.target instanceof Element &&
 			event.target.id === 'map-div'

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -29,11 +29,7 @@
 
 	function handleKeyDown(event: KeyboardEvent) {
 		$InteractionStore.set(event.code, true);
-		if (
-			event.code === 'KeyR' &&
-			event.target instanceof Element &&
-			event.target.id === 'map-div'
-		) {
+		if (event.code === 'KeyR' && event.target instanceof Element && event.target.id === 'map-div') {
 			reapplyPanZoom();
 		}
 	}


### PR DESCRIPTION
This PR adds a key combination (shift+r) to recenter the map. Last two conditions are to make sure that the hotkey does not activate when the user is not focused on the map e.g typing in a text input.