### PR TITLE
Match edit tossup modal style to other candidate modals

### DIFF
--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditTossupModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditTossupModal.svelte
@@ -20,12 +20,16 @@
 		<span>Edit</span>
 		<input
 			type="text"
-			class="input input-bordered w-full max-w-xs"
+			class="input input-sm input-bordered w-full max-w-xs"
 			bind:value={$TossupCandidateStore.name}
 		/>
 	</label>
-	<div slot="content" class="form-control w-full max-w-xs flex flex-col gap-3">
-		<h3 class="font-light text-lg">Color</h3>
-		<input type="color" on:change={updateColor} value={$TossupCandidateStore.margins[0].color} />
+	<div slot="content" class="flex justify-center">
+		<input
+			type="color"
+			class="cursor-pointer"
+			on:change={updateColor}
+			value={$TossupCandidateStore.margins[0].color}
+		/>
 	</div>
 </ModalBase>


### PR DESCRIPTION
Touch up the edit tossup modal to match the other candidate edit modals.

Old:

![image](https://github.com/yapms/yapms/assets/13600696/2313ab7d-2cf6-4f37-86c5-6c756bc6334d)

New:

![image](https://github.com/yapms/yapms/assets/13600696/04148a92-e399-466e-9900-487fbfc4453a)
