### PR TITLE
Ansible quote ENV variables

### DIFF
--- a/deployment/playbooks/deploy-all.yml
+++ b/deployment/playbooks/deploy-all.yml
@@ -85,8 +85,8 @@
         networks:
           - name: yapms
         env:
-          CONCURRENT: 10
-          TOKEN: null
+          CONCURRENT: "10"
+          TOKEN: "null"
 
     - name: deploy postgres
       community.docker.docker_container:


### PR DESCRIPTION
ENV variables that are null or a numeric, need to be quoted.