### PR TITLE
Remove outline from map-div

### DIFF
--- a/apps/yapms/src/routes/app/[country]/+layout.svelte
+++ b/apps/yapms/src/routes/app/[country]/+layout.svelte
@@ -47,7 +47,7 @@
 	<div
 		use:setupMap
 		id="map-div"
-		class="overflow-hidden h-full"
+		class="overflow-hidden h-full outline-none"
 		class:insets-hidden={$MapInsetsStore.hidden}
 		class:texts-hidden={$RegionTextsStore.hidden}
 	>


### PR DESCRIPTION
The outline CSS property controls how the outline shows up with the keyboard controls.

Setting it to none removes the outline.

closes #796 