### PR TITLE
switch to vitePreprocess

### DIFF
--- a/apps/yapms/svelte.config.js
+++ b/apps/yapms/svelte.config.js
@@ -1,12 +1,9 @@
 import adapter from '@sveltejs/adapter-node';
-import { sveltePreprocess } from 'svelte-preprocess';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
-	preprocess: [
-		sveltePreprocess({
-			postcss: true
-		})
-	],
+
+	preprocess: vitePreprocess(),
 
 	kit: {
 		adapter: adapter(),

--- a/apps/yapms/svelte.config.js
+++ b/apps/yapms/svelte.config.js
@@ -2,7 +2,6 @@ import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
-
 	preprocess: vitePreprocess(),
 
 	kit: {


### PR DESCRIPTION
As outlined in the install tailwindcss tutorial. We can use vitePreprocess here.

https://tailwindcss.com/docs/guides/sveltekit

Also noted by sveltekit, it might be faster than sveltePreprocess.

https://kit.svelte.dev/docs/integrations