### PR TITLE
Remove interactions on focus out

### DIFF
--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -45,6 +45,10 @@
 		$InteractionStore.delete(event.code);
 	}
 
+	function handleOnFocusOut() {
+		$InteractionStore.clear();
+	}
+
 	if (browser) {
 		if (innerWidth > 768) {
 			$SideBarStore.open = true;
@@ -57,7 +61,12 @@
 	<meta name="robots" content="nosnippet" />
 </svelte:head>
 
-<svelte:window on:keydown={handleKeyDown} on:keyup={handleKeyUp} on:resize={reapplyPanZoom} />
+<svelte:window
+	on:keydown={handleKeyDown}
+	on:keyup={handleKeyUp}
+	on:resize={reapplyPanZoom}
+	on:focusout={handleOnFocusOut}
+/>
 
 <div class="flex flex-col h-full">
 	{#if $PresentationModeStore.enabled}


### PR DESCRIPTION
Interactions get stored and stuck if they user leaves the window. This deletes all button presses when the users leaves the screen.

closes #844 