### PR TITLE
Popular Maps on Top

### DIFF
--- a/apps/yapms/src/routes/+page.svelte
+++ b/apps/yapms/src/routes/+page.svelte
@@ -114,10 +114,11 @@
 			<MapCardGrid>
 				<UsaMapCard />
 				<UsaPrimariesMapCard />
-
-				<AusMapCard />
-				<BraMapCard />
+				<GbrMapCard />
 				<CanMapCard />
+				<AusMapCard />
+
+				<BraMapCard />
 				<DnkMapCard />
 				<FraMapCard />
 				<DeuMapCard />
@@ -135,7 +136,6 @@
 				<ZafMapCard />
 				<KorMapCard />
 				<EspMapCard />
-				<GbrMapCard />
 
 				<GlbMapCard />
 			</MapCardGrid>


### PR DESCRIPTION
This will put the most popular maps near the top.

The other maps have so few users, that putting them in alphabetical order might make them easier to find.