### PR TITLE
Numeric Input for Split

### DIFF
--- a/apps/yapms/src/lib/components/modals/splitregionmodal/SplitRegionModal.svelte
+++ b/apps/yapms/src/lib/components/modals/splitregionmodal/SplitRegionModal.svelte
@@ -187,6 +187,15 @@
 		$SplitRegionModalStore.region.candidates = generateCandidates();
 		$RegionsStore = $RegionsStore;
 	}
+
+	function preventNonNumericalInput(e: KeyboardEvent) {
+		if (e.key !== 'Enter' && !e.key.match(/^[0-9]+$/)) e.preventDefault();
+	}
+
+	function preventNonNumericalPaste(e: ClipboardEvent) {
+		const pasteContents = e.clipboardData?.getData(e.clipboardData.types[0]);
+		if (!pasteContents?.match(/^[0-9]+$/)) e.preventDefault();
+	}
 </script>
 
 <ModalBase title="Split {$SplitRegionModalStore.region?.longName}" store={SplitRegionModalStore}>
@@ -203,10 +212,26 @@
 							on:click={(event) => updateCandidateMargin(event, candidate)}
 						/>
 					</div>
-					<span class="font-thin font-mono">
-						({candidate.count}/{$SplitRegionModalStore.region?.value})
-						{((candidate.count / ($SplitRegionModalStore.region?.value ?? 1)) * 100).toFixed(2)}%
-					</span>
+					<div class="flex space-x-0 font-thin font-mono">
+						<span class="px-0">(</span>
+						{#if isTossupCandidate(candidate.candidate.id)}
+							<span>{candidate.count}</span>
+						{:else}
+							<input
+								on:change={(event) => updateCandidateCount(event, candidate)}
+								on:keypress={preventNonNumericalInput}
+								on:paste={preventNonNumericalPaste}
+								value={candidate.count}
+								class="rounded-md px-1 text-end resizing-input-split"
+							/>
+						{/if}
+						<span
+							>/{$SplitRegionModalStore.region?.value})
+							{((candidate.count / ($SplitRegionModalStore.region?.value ?? 1)) * 100).toFixed(
+								2
+							)}%</span
+						>
+					</div>
 				</div>
 				<input
 					type="range"

--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -57,3 +57,14 @@ rect {
 .texts-hidden [map-type='button'] {
 	display: none;
 }
+
+.resizing-input-split {
+	max-width: 6ch;
+}
+
+@supports (field-sizing: content) {
+	.resizing-input-split {
+		field-sizing: content;
+		max-width: none;
+	}
+}


### PR DESCRIPTION
This PR adds a numerical input to the split modal for precision when working with larger values.

![yapmsSplitNumeric](https://github.com/user-attachments/assets/6ae1509f-79dd-43eb-92a7-0f50560f80f6)

This PR makes use of a CSS feature, `field-sizing` that is not yet widely available (lacking safari, firefox). To get around that, it uses an `@support` directive for progressive enhancement that will apply styles to make the input resize with content (as seen above) if supported by the browser. If not, the input will be a fixed size of 6 characters. The fixed size is a bit wonky, but will be phased out as Firefox and Webkit adopt the new style.

![image](https://github.com/user-attachments/assets/77c127b3-1b0a-407b-8c0f-37af08b8c18d)
_Split Modal on Firefox_

`preventNonNumericalInput` and `preventNonNumericalPaste` are copy-pasted from the Edit Region Modal.