### PR TITLE
Improved Modal Functionality

### DIFF
--- a/apps/yapms/src/lib/components/modals/ModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/ModalBase.svelte
@@ -16,20 +16,17 @@
 	}
 
 	let content: HTMLDivElement | undefined;
+	let dialog: HTMLDialogElement | undefined;
 	let offsetHeight: number | undefined;
 
 	$: isOverflow = offsetHeight && offsetHeight < (content?.scrollHeight ?? 0);
+
+	$: if ($store.open) dialog?.showModal();
+
+	$: if (!$store.open) dialog?.close();
 </script>
 
-<input
-	aria-hidden="true"
-	tabindex="-1"
-	type="checkbox"
-	class="modal-toggle"
-	checked={$store?.open ?? false}
-/>
-
-<div class="modal modal-bottom lg:modal-middle" on:close={close}>
+<dialog class="modal modal-bottom lg:modal-middle" bind:this={dialog} on:close={close}>
 	<div class="modal-box flex flex-col w-full">
 		<div class="mb-6">
 			<div class="flex gap-x-2 align-middle">
@@ -67,4 +64,4 @@
 	<form method="dialog" class="modal-backdrop">
 		<button on:click={close}>close</button>
 	</form>
-</div>
+</dialog>


### PR DESCRIPTION
This PR is a clone of #287 which changed modals to take advantage of the accessibility improvements of the dialog component (better focusing, can close by clicking outside, can close using escape key)

This PR
- Removes open property & checkbox
- binds dialog element to dialog variable, calls showModal and close on it when the open variable in store changes

We reverted #287 in #329 to fix an issue (#323) where UI would freeze on Mac if a property on the modal store other than the open property was modified. Something (probably a dependency) has changed since then and I've tested this on a Mac running Safari 17.3, Chrome, and Firefox without issue. I also tested this on an old IPad and it was fine.

Additionally, if it was a Safari change, Safari 17.3 (the version I tested on) and later make up above 95% of Safari installations.

All that to say, I think it's fine to merge back in.