### PR TITLE
Fix hiding insets & labels on imported maps

### DIFF
--- a/apps/yapms/src/routes/app/imported/+page.svelte
+++ b/apps/yapms/src/routes/app/imported/+page.svelte
@@ -3,6 +3,7 @@
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 	import { get } from 'svelte/store';
 	import { MapInsetsStore } from '$lib/stores/MapInsetsStore';
+	import { RegionTextsStore } from '$lib/stores/RegionTextsStore';
 	import { applyAutoStroke, applyPanZoom } from '$lib/utils/applyPanZoom';
 	import { loadRegionsForApp } from '$lib/utils/loadRegions';
 	import { setRegionStrokeColor } from '$lib/stores/RegionStrokeColorStore';
@@ -32,7 +33,8 @@
 		use:setupMap
 		id="map-div"
 		class="overflow-hidden h-full"
-		class:insetsHidden={$MapInsetsStore.hidden}
+		class:insets-hidden={$MapInsetsStore.hidden}
+		class:texts-hidden={$RegionTextsStore.hidden}
 	>
 		{@html $ImportedSVGStore.content}
 	</div>


### PR DESCRIPTION
This PR fixes two issues that made insets/labels not hide on imported maps when the corresponding button in options was pressed.

- When changing the class name to hide insets, the name was not changed in the imported route.
- When adding code to hide region labels/buttons, the texts-hidden class conditional was never added to the imported route.