### PR TITLE
Accept .json for GeoJSON imports

### DIFF
--- a/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
@@ -83,7 +83,7 @@
 							<input
 								multiple
 								type="file"
-								accept=".geojson"
+								accept=".geojson, .json"
 								class="file-input file-input-primary w-full"
 								bind:files={geoJsonFiles}
 							/>


### PR DESCRIPTION
This PR adapts the import file dialog for GeoJSON to accept .json in addition to .geojson.

Some places give their GeoJSON using the .json file ending, and it is confusing when you open the file dialog and the file you're looking for isn't there.