### PR TITLE
Increase Maximum Zoom Amount

### DIFF
--- a/apps/yapms/src/lib/utils/applyPanZoom.ts
+++ b/apps/yapms/src/lib/utils/applyPanZoom.ts
@@ -24,7 +24,7 @@ function applyPanZoom(svg: SVGElement) {
 		panZoomSettings.panzoom.dispose();
 	}
 	const panzoomInstance = panzoom(svg, {
-		maxZoom: 100,
+		maxZoom: 500,
 		autocenter: true,
 		zoomDoubleClickSpeed: 1,
 		smoothScroll: false,


### PR DESCRIPTION
This PR increases the amount someone can zoom into the map by 5x. Now that we have the "R" hotkey, I am less worried about someone getting lost unrecoverably. This was asked for by someone making a map with a lot of denser urban clusters.

I limit the zoom to 500 still (it can be infinite!) because after about 500, panzoom starts doing some odd things and the map appears to shift around on zoom rather than properly zoom in. It is still possible to zoom in and out even if panzoom exhibits this behavior.