### PR TITLE
Bug Fixes for Custom Colors

### DIFF
--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte
@@ -49,7 +49,7 @@
 		<button
 			class="btn btn-success"
 			on:click={add}
-			disabled={$AddCustomColorModalStore.newColors < 1}>Confirm</button
+			disabled={$AddCustomColorModalStore.newColors < 1}>Add Colors</button
 		>
 	</div>
 </ModalBase>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte
@@ -49,7 +49,7 @@
 		<button
 			class="btn btn-success"
 			on:click={add}
-			disabled={$AddCustomColorModalStore.newColors < 1}>Add Colors</button
+			disabled={$AddCustomColorModalStore.newColors.length < 1}>Add Colors</button
 		>
 	</div>
 </ModalBase>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte
@@ -32,7 +32,7 @@
 
 <ModalBase title="Add Custom Color" store={AddCustomColorModalStore} onClose={close}>
 	<div slot="content">
-		<div class="flex flex-row flex-wrap gap-3">
+		<div class="flex flex-row flex-wrap gap-3 justify-center">
 			{#each $AddCustomColorModalStore.newColors as color, index}
 				<CustomColor
 					{color}
@@ -46,6 +46,10 @@
 		</div>
 	</div>
 	<div slot="action">
-		<button class="btn btn-success" on:click={add}>add</button>
+		<button
+			class="btn btn-success"
+			on:click={add}
+			disabled={$AddCustomColorModalStore.newColors < 1}>Confirm</button
+		>
 	</div>
 </ModalBase>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/ColorButton.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/ColorButton.svelte
@@ -17,19 +17,22 @@
 		>
 	{/if}
 	<button
-		class="btn btn-lg join-item flex flex-col flex-grow flex-shrink"
+		class="btn btn-lg join-item flex-grow flex-shrink"
+		class:h-fit={name !== undefined}
 		on:click={() => onSelect(colors)}
 	>
-		{#if name !== undefined}
-			<h3 class="font-semibold">{name}</h3>
-		{/if}
-		<div class="flex flex-row flex-wrap gap-2">
-			{#each colors as color}
-				<div
-					class="outline outline-1 outline-white w-4 h-4 rounded-full"
-					style:background-color={color}
-				></div>
-			{/each}
+		<div class="flex flex-col py-2 items-center gap-1">
+			{#if name !== undefined}
+				<h3 class="font-semibold">{name}</h3>
+			{/if}
+			<div class="flex flex-row flex-wrap gap-2">
+				{#each colors as color}
+					<div
+						class="outline outline-1 outline-white w-4 h-4 rounded-full"
+						style:background-color={color}
+					></div>
+				{/each}
+			</div>
 		</div>
 	</button>
 	{#if onDelete !== undefined}

--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/CustomColor.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/CustomColor.svelte
@@ -24,15 +24,15 @@
 </script>
 
 <div class="join items-center">
-	<button class="btn join-item btn-sm" on:click={editColor} style:background-color={color}>
-		<span style:color={textColor}>{color}</span>
+	<button class="btn join-item btn-sm gap-0" on:click={editColor} style:background-color={color}>
 		<input
 			bind:this={colorInput}
 			bind:value={color}
 			type="color"
-			class="hidden"
+			class="w-0"
 			on:change={changeColor}
 		/>
+		<span style:color={textColor}>{color}</span>
 	</button>
 	<button class="btn btn-sm btn-error join-item" on:click={removeColor}
 		><MinusCircle class="w-6 h-6" /></button

--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/EditCustomColorModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/EditCustomColorModal.svelte
@@ -32,7 +32,7 @@
 
 <ModalBase title="Edit Custom Color" store={EditCustomColorModalStore} onClose={close}>
 	<div slot="content">
-		<div class="flex flex-wrap gap-3">
+		<div class="flex flex-wrap gap-3 justify-center">
 			{#each $EditCustomColorModalStore.customColor as color, index}
 				<CustomColor
 					{color}
@@ -46,6 +46,10 @@
 		</div>
 	</div>
 	<div slot="action">
-		<button class="btn btn-success" on:click={confirm}>update</button>
+		<button
+			class="btn btn-success"
+			on:click={confirm}
+			disabled={$EditCustomColorModalStore.customColor.length < 1}>Confirm</button
+		>
 	</div>
 </ModalBase>


### PR DESCRIPTION
This PR fixes some issues with the Custom Colors UI (the Select Preset Colors, Add Custom Color, Edit Custom Color modals). 
- Buttons for presets with names were too short to properly contain both the name and color circles (see below)
![image](https://github.com/user-attachments/assets/e6dddef2-226e-4f35-9d9c-dc10fb9c21e8)

- Colors were not centered in the middle of custom colors modals like they are for candidate modals
- Confirmation buttons had lowercase, non-descriptive text
- Confirmation buttons would not be disabled when there were no colors in the preset.
- The color input opened in the top left due to the input element having the "hidden" class. Fixed this by setting it to width 0 and now it opens in *about* the correct place.
![image](https://github.com/user-attachments/assets/7d3ba59a-4327-461e-8d9c-6e78c5e58be9)

I think in the medium-term this UI should be rewritten to be more in line with the candidate modals (so colors being draggable, etc.) but I did not have time for that today.