### PR TITLE
Fix Color Input Style on Chrome

### DIFF
--- a/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
@@ -85,7 +85,7 @@
 			{#each newColors as color, index (color)}
 				<li class="join">
 					<input
-						class="join-item"
+						class="join-item h-full"
 						type="color"
 						value={color.color}
 						onchange={(change) => {

--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
@@ -122,7 +122,7 @@
 			{#each $CandidatesStore.at(candidateIndex)?.margins || [] as margin, index (margin)}
 				<li class="join">
 					<input
-						class="join-item"
+						class="join-item h-full"
 						type="color"
 						value={margin.color}
 						onchange={(event) => updateColor(event, index)}

--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -80,3 +80,7 @@ rect {
 		max-width: none;
 	}
 }
+
+input[type="color" i]::-webkit-color-swatch-wrapper {
+	padding:0;
+}

--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -81,6 +81,6 @@ rect {
 	}
 }
 
-input[type="color" i]::-webkit-color-swatch-wrapper {
-	padding:0;
+input[type='color' i]::-webkit-color-swatch-wrapper {
+	padding: 0;
 }


### PR DESCRIPTION
This PR brings the color input style on Chrome in line with what those inputs look like on Firefox.

Before:
![image](https://github.com/user-attachments/assets/33cb8d8c-b0c1-4c44-93ac-93d430c32332)

After:
![image](https://github.com/user-attachments/assets/664a02e0-cee0-433b-9fcc-ef299cdecaa9)

Firefox:
![image](https://github.com/user-attachments/assets/94f4c91b-097f-4962-b841-fd1e9b6208a1)
