### PR TITLE
Folders for Saved Maps

### DIFF
--- a/apps/pocketbase/migrations/1749904870_created_user_map_folders.go
+++ b/apps/pocketbase/migrations/1749904870_created_user_map_folders.go
@@ -1,0 +1,102 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		jsonData := `{
+			"createRule": "@request.auth.id != \"\" && @request.auth.id != \"\"",
+			"deleteRule": "@request.auth.id != \"\" && @request.auth.id ?= user.id",
+			"fields": [
+				{
+					"autogeneratePattern": "[a-z0-9]{15}",
+					"hidden": false,
+					"id": "text3208210256",
+					"max": 15,
+					"min": 15,
+					"name": "id",
+					"pattern": "^[a-z0-9]+$",
+					"presentable": false,
+					"primaryKey": true,
+					"required": true,
+					"system": true,
+					"type": "text"
+				},
+				{
+					"cascadeDelete": false,
+					"collectionId": "_pb_users_auth_",
+					"hidden": false,
+					"id": "relation2375276105",
+					"maxSelect": 1,
+					"minSelect": 0,
+					"name": "user",
+					"presentable": false,
+					"required": false,
+					"system": false,
+					"type": "relation"
+				},
+				{
+					"autogeneratePattern": "",
+					"hidden": false,
+					"id": "text1579384326",
+					"max": 0,
+					"min": 0,
+					"name": "name",
+					"pattern": "",
+					"presentable": false,
+					"primaryKey": false,
+					"required": false,
+					"system": false,
+					"type": "text"
+				},
+				{
+					"hidden": false,
+					"id": "autodate2990389176",
+					"name": "created",
+					"onCreate": true,
+					"onUpdate": false,
+					"presentable": false,
+					"system": false,
+					"type": "autodate"
+				},
+				{
+					"hidden": false,
+					"id": "autodate3332085495",
+					"name": "updated",
+					"onCreate": true,
+					"onUpdate": true,
+					"presentable": false,
+					"system": false,
+					"type": "autodate"
+				}
+			],
+			"id": "pbc_1718115395",
+			"indexes": [],
+			"listRule": "@request.auth.id != \"\" && user.id ?= @request.auth.id",
+			"name": "user_map_folders",
+			"system": false,
+			"type": "base",
+			"updateRule": "@request.auth.id != \"\" && @request.auth.id ?= user.id",
+			"viewRule": "@request.auth.id != \"\" && user.id ?= @request.auth.id"
+		}`
+
+		collection := &core.Collection{}
+		if err := json.Unmarshal([]byte(jsonData), &collection); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_1718115395")
+		if err != nil {
+			return err
+		}
+
+		return app.Delete(collection)
+	})
+}

--- a/apps/pocketbase/migrations/1749905772_updated_user_maps.go
+++ b/apps/pocketbase/migrations/1749905772_updated_user_maps.go
@@ -1,0 +1,44 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("et0wg1x7mdn55wc")
+		if err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(4, []byte(`{
+			"cascadeDelete": false,
+			"collectionId": "pbc_1718115395",
+			"hidden": false,
+			"id": "relation3970042317",
+			"maxSelect": 1,
+			"minSelect": 0,
+			"name": "folder",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "relation"
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("et0wg1x7mdn55wc")
+		if err != nil {
+			return err
+		}
+
+		// remove field
+		collection.Fields.RemoveById("relation3970042317")
+
+		return app.Save(collection)
+	})
+}

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
@@ -4,12 +4,13 @@
 	import PlusCircle from '$lib/icons/PlusCircle.svelte';
 	import { page } from '$app/stores';
 	import Folder from '$lib/icons/Folder.svelte';
+	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 
-	export let disabled = false;
-	export let onSubmitted: () => void;
+	let { disabled, onSubmitted }: { disabled: boolean, onSubmitted: () => void } = $props();
 
-	let submitting = false;
-	let newMapName = '';
+	let error = $state<string>('');
+	let submitting = $state<boolean>(false);
+	let newMapName = $state<string>('');
 
 	async function createMap() {
 		if (newMapName === '') {
@@ -19,6 +20,7 @@
 			return;
 		}
 		submitting = true;
+		error = '';
 		const form = new FormData();
 		const newMapData = new File([JSON.stringify(generateJson())], 'data.json', {
 			type: 'application/json'
@@ -26,12 +28,18 @@
 		form.append('data', newMapData);
 		form.append('name', newMapName);
 		form.append('user', $PocketBaseStore.authStore.record.id);
-		await $PocketBaseStore.collection('user_maps').create(form);
-		submitting = false;
-		newMapName = '';
-		onSubmitted();
+		await $PocketBaseStore.collection('user_maps').create(form)
+		.then(() => {
+			submitting = false;
+			newMapName = '';
+			onSubmitted();
+		})
+		.catch((e) => {
+			console.error(e);
+			error = e.message;
+			submitting = false;
+		});
 	}
-	console.log($page.url.pathname.split('/').at(2));
 
 	async function createFolder() {
 		if (newMapName === '') {
@@ -41,15 +49,29 @@
 			return;
 		}
 		submitting = true;
+		error = '';
 		await $PocketBaseStore.collection('user_map_folders').create({
 			name: newMapName,
 			user: $PocketBaseStore.authStore.record.id
+		}).then(() => {
+			submitting = false;
+			newMapName = '';
+			onSubmitted();
+		})
+		.catch((e) => {
+			console.error(e);
+			error = e.message;
+			submitting = false;
 		});
-		submitting = false;
-		newMapName = '';
-		onSubmitted();
 	}
 </script>
+
+{#if error}
+	<div class="alert alert-error gap-x-2 p-2">
+		<ExclamationCircle class="w-5 h-5" />
+		<span>{error}</span>
+	</div>
+{/if}
 
 <div class="join">
 	<input
@@ -62,7 +84,7 @@
 	<div class="tooltip" data-tip="New Folder">
 		<button
 			class="btn btn-sm join-item"
-			on:click={createFolder}
+			onclick={createFolder}
 			disabled={disabled || submitting || $page.url.pathname === '/app/imported'}
 		>
 			{#if submitting}
@@ -75,7 +97,7 @@
 	<div class="tooltip" data-tip="New Map">
 		<button
 			class="btn btn-sm btn-primary join-item"
-			on:click={createMap}
+			onclick={createMap}
 			disabled={disabled || submitting || $page.url.pathname === '/app/imported'}
 		>
 			{#if submitting}

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
@@ -89,7 +89,7 @@
 	/>
 	<div class="tooltip" data-tip="New Folder">
 		<button
-			class="btn btn-sm join-item"
+			class="btn btn-sm btn-primary join-item"
 			onclick={createFolder}
 			disabled={disabled || submitting || $page.url.pathname === '/app/imported'}
 		>

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
@@ -3,6 +3,7 @@
 	import { generateJson } from '$lib/utils/saveMap';
 	import PlusCircle from '$lib/icons/PlusCircle.svelte';
 	import { page } from '$app/stores';
+	import Folder from '$lib/icons/Folder.svelte';
 
 	export let disabled = false;
 	export let onSubmitted: () => void;
@@ -14,7 +15,7 @@
 		if (newMapName === '') {
 			return;
 		}
-		if ($PocketBaseStore.authStore.model === null) {
+		if ($PocketBaseStore.authStore.record === null) {
 			return;
 		}
 		submitting = true;
@@ -24,13 +25,30 @@
 		});
 		form.append('data', newMapData);
 		form.append('name', newMapName);
-		form.append('user', $PocketBaseStore.authStore.model.id);
+		form.append('user', $PocketBaseStore.authStore.record.id);
 		await $PocketBaseStore.collection('user_maps').create(form);
 		submitting = false;
 		newMapName = '';
 		onSubmitted();
 	}
 	console.log($page.url.pathname.split('/').at(2));
+
+	async function createFolder() {
+		if (newMapName === '') {
+			return;
+		}
+		if ($PocketBaseStore.authStore.record === null) {
+			return;
+		}
+		submitting = true;
+		await $PocketBaseStore.collection('user_map_folders').create({
+			name: newMapName,
+			user: $PocketBaseStore.authStore.record.id
+		});
+		submitting = false;
+		newMapName = '';
+		onSubmitted();
+	}
 </script>
 
 <div class="join">
@@ -38,10 +56,23 @@
 		type="text"
 		class="input input-bordered input-sm flex-grow overflow-hidden join-item"
 		bind:value={newMapName}
-		placeholder="Map Name"
+		placeholder="Map/Folder Name"
 		disabled={disabled || submitting || $page.url.pathname === '/app/imported'}
 	/>
-	<div class="tooltip" data-tip="Create">
+	<div class="tooltip" data-tip="New Folder">
+		<button
+			class="btn btn-sm join-item"
+			on:click={createFolder}
+			disabled={disabled || submitting || $page.url.pathname === '/app/imported'}
+		>
+			{#if submitting}
+				<span class="loading loading-dots loading-sm"></span>
+			{:else}
+				<Folder class="w-6 h-6" />
+			{/if}
+		</button>
+	</div>
+	<div class="tooltip" data-tip="New Map">
 		<button
 			class="btn btn-sm btn-primary join-item"
 			on:click={createMap}

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
@@ -6,7 +6,7 @@
 	import Folder from '$lib/icons/Folder.svelte';
 	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 
-	let { disabled, onSubmitted }: { disabled: boolean, onSubmitted: () => void } = $props();
+	let { disabled, onSubmitted }: { disabled: boolean; onSubmitted: () => void } = $props();
 
 	let error = $state<string>('');
 	let submitting = $state<boolean>(false);
@@ -28,17 +28,19 @@
 		form.append('data', newMapData);
 		form.append('name', newMapName);
 		form.append('user', $PocketBaseStore.authStore.record.id);
-		await $PocketBaseStore.collection('user_maps').create(form)
-		.then(() => {
-			submitting = false;
-			newMapName = '';
-			onSubmitted();
-		})
-		.catch((e) => {
-			console.error(e);
-			error = e.message;
-			submitting = false;
-		});
+		await $PocketBaseStore
+			.collection('user_maps')
+			.create(form)
+			.then(() => {
+				submitting = false;
+				newMapName = '';
+				onSubmitted();
+			})
+			.catch((e) => {
+				console.error(e);
+				error = e.message;
+				submitting = false;
+			});
 	}
 
 	async function createFolder() {
@@ -50,19 +52,22 @@
 		}
 		submitting = true;
 		error = '';
-		await $PocketBaseStore.collection('user_map_folders').create({
-			name: newMapName,
-			user: $PocketBaseStore.authStore.record.id
-		}).then(() => {
-			submitting = false;
-			newMapName = '';
-			onSubmitted();
-		})
-		.catch((e) => {
-			console.error(e);
-			error = e.message;
-			submitting = false;
-		});
+		await $PocketBaseStore
+			.collection('user_map_folders')
+			.create({
+				name: newMapName,
+				user: $PocketBaseStore.authStore.record.id
+			})
+			.then(() => {
+				submitting = false;
+				newMapName = '';
+				onSubmitted();
+			})
+			.catch((e) => {
+				console.error(e);
+				error = e.message;
+				submitting = false;
+			});
 	}
 </script>
 

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SaveMap.svelte
@@ -6,8 +6,9 @@
 	import Folder from '$lib/icons/Folder.svelte';
 	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 
-	let { disabled, onSubmitted }: { disabled: boolean; onSubmitted: () => void } = $props();
+	let { onSubmitted }: { onSubmitted: () => void } = $props();
 
+	let disabled = $state<boolean>(false);
 	let error = $state<string>('');
 	let submitting = $state<boolean>(false);
 	let newMapName = $state<string>('');

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMap.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMap.svelte
@@ -10,7 +10,7 @@
 
 	export let mapName: string;
 	export let mapID: string;
-	export let onDeleted: () => void;
+	export let onUpdated: () => void;
 
 	let submitting = false;
 
@@ -18,7 +18,7 @@
 		submitting = true;
 		await $PocketBaseStore.collection('user_maps').delete(mapID);
 		submitting = false;
-		onDeleted();
+		onUpdated();
 	}
 
 	async function openMap() {
@@ -29,7 +29,7 @@
 	}
 </script>
 
-<div class="join">
+<div class="join z-20" data-map-id={mapID}>
 	<button
 		class="btn btn-sm flex-shrink flex-grow join-item overflow-hidden"
 		on:click={openMap}
@@ -37,7 +37,7 @@
 	>
 		{mapName}
 	</button>
-	<div class="tooltip" data-tip="Delete">
+	<div class="tooltip tooltip-left" data-tip="Delete">
 		<button
 			class="btn btn-sm btn-error flex-shrink join-item"
 			on:click={deleteMap}

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import MinusCircle from '$lib/icons/MinusCircle.svelte';
+	import { PocketBaseStore } from '$lib/stores/PocketBase';
+	import { updateSavedMapFolder } from '$lib/utils/savedMaps';
+	import { useSortable } from '$lib/utils/sortableHook.svelte';
+	import SavedMap from './SavedMap.svelte';
+
+	let {
+		folderName,
+		folderID,
+		open,
+		onUpdated,
+		onToggle
+	}: {
+		folderName: string;
+		folderID: string;
+		open: boolean;
+		onUpdated: () => void;
+		onToggle: (folderID: string) => void;
+	} = $props();
+
+	const maps = $PocketBaseStore.collection('user_maps').getFullList({
+		filter: `folder = '${folderID}'`,
+		requestKey: null
+	});
+
+	let submitting = $state(false);
+
+	async function deleteFolder() {
+		submitting = true;
+		await $PocketBaseStore.collection('user_map_folders').delete(folderID);
+		submitting = false;
+		onUpdated();
+	}
+
+	let mapList = $state<HTMLDivElement | undefined>(undefined);
+
+	$effect(() => {
+		useSortable(() => mapList, {
+			animation: 140,
+			dragoverBubble: true,
+			delay: 250,
+			delayOnTouchOnly: true,
+			group: 'user-maps',
+			sort: false,
+			disabled: !open,
+			ghostClass: 'z-10',
+			async onAdd(evt) {
+				await updateSavedMapFolder(evt, folderID);
+				onUpdated();
+			}
+		});
+	});
+
+	function onCheck() {
+		onToggle(folderID);
+	}
+</script>
+
+<div class="collapse bg-base-300 border-base-300 rounded-r-none">
+	<input type="checkbox" bind:checked={open} onchange={onCheck} />
+	<div class="collapse-title join p-0 flex items-center transition-[padding]" class:pb-2={open}>
+		<p class="text-xs font-semibold p-0 grow text-center">{folderName}</p>
+		<div class="tooltip tooltip-left z-10" data-tip="Delete">
+			<button
+				class="btn btn-sm btn-error flex-shrink join-item"
+				class:rounded-br-none={open}
+				class:rounded-bl-sm={open}
+				onclick={deleteFolder}
+				disabled={submitting}
+			>
+				<MinusCircle class="w-6 h-6" />
+			</button>
+		</div>
+	</div>
+
+	<div class="collapse-content">
+		<div class="flex flex-col gap-2 min-h-8" bind:this={mapList}>
+			{#await maps}
+				<div class="flex justify-center">
+					<span class="loading loading-dots loading-lg"></span>
+				</div>
+			{:then maps}
+				<div
+					class="absolute w-[calc(100%-8*var(--spacing))] h-8 rounded-md border-2 border-dashed border-opacity-20 border-base-content/30 z-10"
+				></div>
+				{#each maps.sort((a, b) => a.name.localeCompare(b.name)) as map}
+					<SavedMap mapName={map.name} mapID={map.id} {onUpdated} />
+				{/each}
+			{/await}
+		</div>
+	</div>
+</div>

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
@@ -71,10 +71,10 @@
 <div class="collapse collapse-arrow bg-base-300 border-base-300 rounded-r-none">
 	<input type="checkbox" bind:checked={open} onchange={onCheck} />
 	<div
-		class="truncate collapse-title join p-0 flex items-center transition-[padding] after:mr-10 after:-mt-3.5"
+		class="truncate collapse-title join p-0 flex items-center transition-[padding] after:mr-[calc(100%-2.5rem)] after:-mt-3.5"
 		class:pb-2={open}
 	>
-		<p class="truncate text-xs font-semibold pr-8 pl-4 grow text-center">{folderName}</p>
+		<p class="truncate text-xs font-semibold pr-4 pl-8 grow text-center">{folderName}</p>
 		<div class="tooltip tooltip-left z-10" data-tip="Delete">
 			<button
 				class="btn btn-sm btn-error flex-shrink join-item"

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
@@ -3,6 +3,7 @@
 	import { PocketBaseStore } from '$lib/stores/PocketBase';
 	import { updateSavedMapFolder } from '$lib/utils/savedMaps';
 	import { useSortable } from '$lib/utils/sortableHook.svelte';
+	import type { RecordModel } from 'pocketbase';
 	import SavedMap from './SavedMap.svelte';
 
 	let {
@@ -19,10 +20,7 @@
 		onToggle: (folderID: string) => void;
 	} = $props();
 
-	const maps = $PocketBaseStore.collection('user_maps').getFullList({
-		filter: `folder = '${folderID}'`,
-		requestKey: null
-	});
+	let maps = $state<Promise<RecordModel[]>>(Promise.resolve([]));
 
 	let submitting = $state(false);
 
@@ -53,6 +51,12 @@
 	});
 
 	function onCheck() {
+		if (open) {
+			maps = $PocketBaseStore.collection('user_maps').getFullList({
+				filter: `folder = '${folderID}'`,
+				requestKey: null
+			});
+		}
 		onToggle(folderID);
 	}
 </script>

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
@@ -20,7 +20,14 @@
 		onToggle: (folderID: string) => void;
 	} = $props();
 
-	let maps = $state<Promise<RecordModel[]>>(Promise.resolve([]));
+	let maps = $state<Promise<RecordModel[]>>(
+		open
+			? $PocketBaseStore.collection('user_maps').getFullList({
+					filter: `folder = '${folderID}'`,
+					requestKey: null
+				})
+			: Promise.resolve([])
+	);
 
 	let submitting = $state(false);
 

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
@@ -68,10 +68,13 @@
 	}
 </script>
 
-<div class="collapse bg-base-300 border-base-300 rounded-r-none">
+<div class="collapse collapse-arrow bg-base-300 border-base-300 rounded-r-none">
 	<input type="checkbox" bind:checked={open} onchange={onCheck} />
-	<div class="collapse-title join p-0 flex items-center transition-[padding]" class:pb-2={open}>
-		<p class="text-xs font-semibold p-0 grow text-center">{folderName}</p>
+	<div
+		class="truncate collapse-title join p-0 flex items-center transition-[padding] after:mr-10 after:-mt-3.5"
+		class:pb-2={open}
+	>
+		<p class="truncate text-xs font-semibold pr-8 pl-4 grow text-center">{folderName}</p>
 		<div class="tooltip tooltip-left z-10" data-tip="Delete">
 			<button
 				class="btn btn-sm btn-error flex-shrink join-item"

--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMaps.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMaps.svelte
@@ -1,25 +1,78 @@
 <script lang="ts">
 	import { PocketBaseStore } from '$lib/stores/PocketBase';
+	import { updateSavedMapFolder } from '$lib/utils/savedMaps';
+	import { useSortable } from '$lib/utils/sortableHook.svelte';
 	import SavedMap from './SavedMap.svelte';
+	import SavedMapFolder from './SavedMapFolder.svelte';
 	import SaveMap from './SaveMap.svelte';
 
-	let maps = $PocketBaseStore.collection('user_maps').getFullList();
+	let maps = $state(
+		$PocketBaseStore.collection('user_maps').getFullList({
+			filter: "folder = ''"
+		})
+	);
+
+	let folders = $state($PocketBaseStore.collection('user_map_folders').getFullList());
 
 	function refreshMaps() {
-		maps = $PocketBaseStore.collection('user_maps').getFullList();
+		maps = $PocketBaseStore.collection('user_maps').getFullList({ filter: "folder = ''" });
+		folders = $PocketBaseStore.collection('user_map_folders').getFullList();
+	}
+
+	let mapList = $state<HTMLDivElement | undefined>(undefined);
+
+	useSortable(() => mapList, {
+		animation: 140,
+		dragoverBubble: true,
+		delay: 250,
+		delayOnTouchOnly: true,
+		group: 'user-maps',
+		sort: false,
+		async onAdd(evt) {
+			await updateSavedMapFolder(evt, '');
+			refreshMaps();
+		}
+	});
+
+	let openFolders = $state<Map<string, boolean>>(new Map<string, boolean>());
+
+	function onFolderToggle(folderID: string) {
+		if (openFolders.get(folderID) === true) {
+			openFolders.set(folderID, false);
+		} else {
+			openFolders.set(folderID, true);
+		}
 	}
 </script>
 
 <div class="divider">Saved Maps</div>
 <div class="flex flex-col gap-2 p-4">
 	<SaveMap onSubmitted={refreshMaps} />
+	{#await folders}
+		<div class="flex justify-center">
+			<span class="loading loading-dots loading-lg"></span>
+		</div>
+	{:then folders}
+		{#each folders.sort((a, b) => a.name.localeCompare(b.name)) as folder}
+			<SavedMapFolder
+				folderName={folder.name}
+				folderID={folder.id}
+				onUpdated={refreshMaps}
+				open={openFolders.get(folder.id) === true}
+				onToggle={onFolderToggle}
+			/>
+		{/each}
+	{/await}
+
 	{#await maps}
 		<div class="flex justify-center">
 			<span class="loading loading-dots loading-lg"></span>
 		</div>
 	{:then maps}
-		{#each maps.sort((a, b) => a.name.localeCompare(b.name)) as map}
-			<SavedMap mapName={map.name} mapID={map.id} onDeleted={refreshMaps} />
-		{/each}
+		<div class="flex flex-col gap-2" bind:this={mapList}>
+			{#each maps.sort((a, b) => a.name.localeCompare(b.name)) as map}
+				<SavedMap mapName={map.name} mapID={map.id} onUpdated={refreshMaps} />
+			{/each}
+		</div>
 	{/await}
 </div>

--- a/apps/yapms/src/lib/icons/Folder.svelte
+++ b/apps/yapms/src/lib/icons/Folder.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	let className = '';
+	export { className as class };
+	export let style = '';
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	fill="currentColor"
+	viewBox="0 0 512 512"
+	stroke="none"
+	class={className}
+	{style}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M0 96C0 60.7 28.7 32 64 32l132.1 0c19.1 0 37.4 7.6 50.9 21.1L289.9 96 448 96c35.3 0 64 28.7 64 64l0 256c0 35.3-28.7 64-64 64L64 480c-35.3 0-64-28.7-64-64L0 96zM64 80c-8.8 0-16 7.2-16 16l0 320c0 8.8 7.2 16 16 16l384 0c8.8 0 16-7.2 16-16l0-256c0-8.8-7.2-16-16-16l-161.4 0c-10.6 0-20.8-4.2-28.3-11.7L213.1 87c-4.5-4.5-10.6-7-17-7L64 80z"
+	/>
+</svg>

--- a/apps/yapms/src/lib/utils/savedMaps.ts
+++ b/apps/yapms/src/lib/utils/savedMaps.ts
@@ -1,0 +1,12 @@
+import { PocketBaseStore } from '$lib/stores/PocketBase';
+import type { SortableEvent } from 'sortablejs';
+import { get } from 'svelte/store';
+
+export async function updateSavedMapFolder(evt: SortableEvent, newFolderID: string) {
+	const mapID = evt.item.getAttribute('data-map-id');
+	if (mapID) {
+		return get(PocketBaseStore).collection('user_maps').update(mapID, {
+			folder: newFolderID
+		});
+	}
+}


### PR DESCRIPTION
This PR adds the ability to create folders with which you can organize your saved maps.

To add support for this on the backend, there are two migrations. The first one created the user_map_folders table with two properties, name and user. The second migration adds a folder property to the user_maps table.