### PR TITLE
Better Regions Table Sort

### DIFF
--- a/apps/yapms/src/lib/components/modals/toolsmodal/tools/TableModal.svelte
+++ b/apps/yapms/src/lib/components/modals/toolsmodal/tools/TableModal.svelte
@@ -14,7 +14,7 @@
 			return region.longName.toLowerCase().trim().includes(lowerSearch) || lowerSearch == '';
 		})
 		.sort((regionA, regionB) => {
-			return regionA.longName > regionB.longName ? 1 : -1;
+			return regionA.longName.localeCompare(regionB.longName, undefined, { numeric: true });
 		});
 
 	function updateRegionValue(


### PR DESCRIPTION
This PR changes the sort in the regions table to use toLocaleCompare, which fixes issues with districts being out of numerical order.

For example, using the current sort:
![image](https://github.com/user-attachments/assets/5dcc97da-595b-4cfa-86a6-c19f4fa6dcbb)
(1-9 are buried within the other districts, so 2 is only after 19, etc.)

With the new sort:
![image](https://github.com/user-attachments/assets/d4d212c4-6e4c-4078-8928-33b8f0f0fe38)

I think this also fixes issues that the sort had with Canadian ridings where ridings that contained characters with accents were sometimes misplaced.
