### PR TITLE
Modal Toggle Keybinds

### DIFF
--- a/apps/yapms/src/lib/components/modals/modemodal/ModeModal.svelte
+++ b/apps/yapms/src/lib/components/modals/modemodal/ModeModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import QuestionMarkCircle from '$lib/icons/QuestionMarkCircle.svelte';
 	import { ModeModalStore } from '$lib/stores/Modals';
 	import { ModeStore } from '$lib/stores/Mode';
 	import type { Mode } from '$lib/types/Mode';
@@ -30,5 +31,13 @@
 				</button>
 			{/each}
 		</div>
+	</div>
+	<div slot="action" class="flex w-full gap-1 self-center items-center font-thin">
+		<QuestionMarkCircle class="w-5 h-5" style="stroke-width: 0.75px" />
+		<span
+			>Press <kbd class="kbd kbd-sm">f</kbd>, <kbd class="kbd kbd-sm">s</kbd>,
+			<kbd class="kbd kbd-sm">e</kbd>,
+			<kbd class="kbd kbd-sm">d</kbd>, or <kbd class="kbd kbd-sm">l</kbd> to quick select</span
+		>
 	</div>
 </ModalBase>

--- a/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
@@ -20,7 +20,7 @@
 	<div>Switch candidates.</div>
 
 	<div class="col-span-2 text-center content-center">
-		Hold <kbd class="kbd">shift</kbd> and Press
+		Press
 		<div class="flex flex-wrap justify-center gap-x-1 mt-1">
 			<kbd class="kbd">h</kbd>
 			<kbd class="kbd">c</kbd>

--- a/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/shortcuts/Shortcuts.svelte
@@ -19,6 +19,21 @@
 	</div>
 	<div>Switch candidates.</div>
 
+	<div class="col-span-2 text-center content-center">
+		Hold <kbd class="kbd">shift</kbd> and Press
+		<div class="flex flex-wrap justify-center gap-x-1 mt-1">
+			<kbd class="kbd">h</kbd>
+			<kbd class="kbd">c</kbd>
+			<kbd class="kbd">i</kbd>
+			<kbd class="kbd">o</kbd>
+			<kbd class="kbd">m</kbd>
+			<kbd class="kbd">s</kbd>
+			<kbd class="kbd">t</kbd>
+			<kbd class="kbd">l</kbd>
+		</div>
+		to toggle menus.
+	</div>
+
 	{#if $ActionGroups.length !== 0}
 		<div class="text-right content-center">Hold <kbd class="kbd">g</kbd></div>
 		<div class="flex flex-col">

--- a/apps/yapms/src/lib/stores/Modals.ts
+++ b/apps/yapms/src/lib/stores/Modals.ts
@@ -1,6 +1,8 @@
 import { get, writable } from 'svelte/store';
+import type { Writable } from 'svelte/store';
 import type { Region } from '$lib/types/Region';
 import { TossupCandidateStore } from './Candidates';
+import { ModeStore } from './Mode';
 
 export const CandidateModalStore = writable({
 	open: false
@@ -73,6 +75,32 @@ export const ModeModalStore = writable({
 	open: false
 });
 
+export function handleModeInteractions(keycode: string) {
+	switch (keycode) {
+		case 'KeyF':
+			ModeStore.set('fill');
+			break;
+		case 'KeyD':
+			ModeStore.set('disable');
+			break;
+		case 'KeyL':
+			ModeStore.set('lock');
+			break;
+		case 'KeyS':
+			ModeStore.set('split');
+			break;
+		case 'KeyE':
+			ModeStore.set('edit');
+			break;
+		default:
+			return;
+	}
+	ModeModalStore.set({
+		open: false,
+		...ModeModalStore
+	});
+}
+
 export const ShareModalStore = writable({
 	open: false
 });
@@ -113,3 +141,40 @@ export const MassEditModalStore = writable({
 export const TableModalStore = writable({
 	open: false
 });
+
+function toggleOpen(store: Writable<{ open: boolean }>) {
+	const openVal = get(store).open;
+	store.set({
+		open: !openVal,
+		...store
+	});
+}
+
+export function handleModalOpenInteractions(keycode: string) {
+	switch (keycode) {
+		case 'KeyH':
+			toggleOpen(NavigateHomeModalStore);
+			break;
+		case 'KeyC':
+			toggleOpen(CandidateModalStore);
+			break;
+		case 'KeyI':
+			toggleOpen(ImportModalStore);
+			break;
+		case 'KeyO':
+			toggleOpen(OptionsModalStore);
+			break;
+		case 'KeyM':
+			toggleOpen(ModeModalStore);
+			break;
+		case 'KeyS':
+			toggleOpen(ShareModalStore);
+			break;
+		case 'KeyT':
+			toggleOpen(ThemeModalStore);
+			break;
+		case 'KeyL':
+			toggleOpen(AuthModalStore);
+			break;
+	}
+}

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -47,7 +47,7 @@
 		}
 
 		if (event.target instanceof Element && event.target.tagName !== 'INPUT') {
-			if (event.shiftKey && !event.ctrlKey) {
+			if (!event.ctrlKey && !$ModeModalStore.open) {
 				handleModalOpenInteractions(event.code);
 			}
 			if ($ModeModalStore.open) {

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -30,6 +30,11 @@
 	import { PresentationModeStore } from '$lib/stores/PresentationMode';
 	import PresentationNavBar from '$lib/components/navbar/PresentationNavBar.svelte';
 	import ToolsModal from '$lib/components/modals/toolsmodal/ToolsModal.svelte';
+	import {
+		ModeModalStore,
+		handleModeInteractions,
+		handleModalOpenInteractions
+	} from '$lib/stores/Modals';
 
 	function handleKeyDown(event: KeyboardEvent) {
 		$InteractionStore.set(event.code, true);
@@ -39,6 +44,15 @@
 				reapplyPanZoom();
 			}
 			handleCandidateSelectionShortcut(event.code);
+		}
+
+		if (event.target instanceof Element && event.target.tagName !== 'INPUT') {
+			if (event.shiftKey && !event.ctrlKey) {
+				handleModalOpenInteractions(event.code);
+			}
+			if ($ModeModalStore.open) {
+				handleModeInteractions(event.code);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds hotkeys for opening modals. It also adds the ability to select a mode with your keyboard, so you can do a key combination to switch modes (ex: Shift+M+F will switch you to fill)

A lot of switch statement here but I think that's the only way this works.