### PR TITLE
Revert to old table sort and remove some overhead from region actions

### DIFF
--- a/apps/yapms/src/lib/components/modals/toolsmodal/tools/TableModal.svelte
+++ b/apps/yapms/src/lib/components/modals/toolsmodal/tools/TableModal.svelte
@@ -8,14 +8,16 @@
 	import { preventNonNumericalInput, preventNonNumericalPaste } from '$lib/utils/inputValidation';
 
 	let filterInput = '';
-	$: sortedAndFilteredRegions = $RegionsStore
-		.filter((region) => {
-			const lowerSearch = filterInput.toLowerCase().trim();
-			return region.longName.toLowerCase().trim().includes(lowerSearch) || lowerSearch == '';
-		})
-		.sort((regionA, regionB) => {
-			return regionA.longName.localeCompare(regionB.longName, undefined, { numeric: true });
-		});
+	$: sortedAndFilteredRegions = $TableModalStore.open
+		? $RegionsStore
+				.filter((region) => {
+					const lowerSearch = filterInput.toLowerCase().trim();
+					return region.longName.toLowerCase().trim().includes(lowerSearch) || lowerSearch == '';
+				})
+				.sort((regionA, regionB) => {
+					return regionA.longName > regionB.longName ? 1 : -1;
+				})
+		: [];
 
 	function updateRegionValue(
 		event: Event & { currentTarget: EventTarget & HTMLInputElement },


### PR DESCRIPTION
This PR does two things:
1. Reverts back to the method of table sorting we were using before my PR the other day. I did not realize just how much performance would be lost by doing localeCompare. It's enough to the point that I am willing to accept the sort being bad for the UI not being sluggish.
2. Makes the regions table not run it's sort/filter logic if the table is not actually open. This should remove a large chunk of what happens when a region is changed,

I also experimented with making the table only sort when it's opened and having all other operations not update the entire array and trigger a resort but only update the element that was changed.