### PR TITLE
Select for GeoJSON Properties

### DIFF
--- a/apps/yapms/src/lib/components/modals/importmodal/GeoJSONOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/GeoJSONOptions.svelte
@@ -19,7 +19,7 @@
 		bind:value={$ImportedSVGStore.options.shortNameProp}
 	>
 		{#await properties}
-			<option value=''>Loading...</option>
+			<option value="">Loading...</option>
 		{:then properties}
 			{#each properties as property}
 				<option value={property}>{property}</option>
@@ -34,7 +34,7 @@
 		bind:value={$ImportedSVGStore.options.longNameProp}
 	>
 		{#await properties}
-			<option value=''>Loading...</option>
+			<option value="">Loading...</option>
 		{:then properties}
 			{#each properties as property}
 				<option value={property}>{property}</option>
@@ -49,7 +49,7 @@
 		bind:value={$ImportedSVGStore.options.valueProp}
 	>
 		{#await properties}
-			<option value=''>Loading...</option>
+			<option value="">Loading...</option>
 		{:then properties}
 			{#each properties as property}
 				<option value={property}>{property}</option>

--- a/apps/yapms/src/lib/components/modals/importmodal/GeoJSONOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/GeoJSONOptions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 
-	let { disabled = false } = $props();
+	let { disabled = false, properties } = $props();
 </script>
 
 <fieldset class="fieldset">
@@ -13,26 +13,47 @@
 	</p>
 
 	<p class="fieldset-label">Short Name - Used as the region tooltip.</p>
-	<input
-		type="text"
-		class="input w-full"
+	<select
+		class="select select-bordered w-full"
 		{disabled}
 		bind:value={$ImportedSVGStore.options.shortNameProp}
-	/>
+	>
+		{#await properties}
+			<option value=''>Loading...</option>
+		{:then properties}
+			{#each properties as property}
+				<option value={property}>{property}</option>
+			{/each}
+		{/await}
+	</select>
 
 	<p class="fieldset-label">Long Name - Shown when editing or splitting a region.</p>
-	<input
-		type="text"
-		class="input w-full"
+	<select
+		class="select select-bordered w-full"
 		{disabled}
 		bind:value={$ImportedSVGStore.options.longNameProp}
-	/>
+	>
+		{#await properties}
+			<option value=''>Loading...</option>
+		{:then properties}
+			{#each properties as property}
+				<option value={property}>{property}</option>
+			{/each}
+		{/await}
+	</select>
 
 	<p class="fieldset-label">Value - The value of the region, must be numeric.</p>
-	<input
-		type="text"
-		class="input w-full"
+	<select
+		class="select select-bordered w-full"
 		{disabled}
 		bind:value={$ImportedSVGStore.options.valueProp}
-	/>
+	>
+		{#await properties}
+			<option value=''>Loading...</option>
+		{:then properties}
+			{#each properties as property}
+				<option value={property}>{property}</option>
+			{/each}
+		{/await}
+	</select>
 </fieldset>

--- a/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { ImportModalStore } from '$lib/stores/Modals';
-	import { importFromGeoJson, importFromShapefiles, importFromSVG, getGeoJsonProperties } from '$lib/utils/importMap';
+	import {
+		importFromGeoJson,
+		importFromShapefiles,
+		importFromSVG,
+		getGeoJsonProperties
+	} from '$lib/utils/importMap';
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 	import ModalBase from '../ModalBase.svelte';
@@ -36,7 +41,7 @@
 
 	let geoJsonProperties = $derived(
 		files && fileType === 'geojson' ? getGeoJsonProperties(files) : []
-	)
+	);
 
 	let fileTypeIsInvalid = $derived(
 		files && files.length > 0 && ['geojson', 'shp', 'svg'].includes(fileType) === false

--- a/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ImportModalStore } from '$lib/stores/Modals';
-	import { importFromGeoJson, importFromShapefiles, importFromSVG } from '$lib/utils/importMap';
+	import { importFromGeoJson, importFromShapefiles, importFromSVG, getGeoJsonProperties } from '$lib/utils/importMap';
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 	import ExclamationCircle from '$lib/icons/ExclamationCircle.svelte';
 	import ModalBase from '../ModalBase.svelte';
@@ -33,6 +33,10 @@
 			return 'invalid';
 		}, '')
 	);
+
+	let geoJsonProperties = $derived(
+		files && fileType === 'geojson' ? getGeoJsonProperties(files) : []
+	)
 
 	let fileTypeIsInvalid = $derived(
 		files && files.length > 0 && ['geojson', 'shp', 'svg'].includes(fileType) === false
@@ -127,7 +131,7 @@
 				{/if}
 
 				{#if fileType === 'geojson'}
-					<GeoJsonOptions disabled={isLoading} />
+					<GeoJsonOptions disabled={isLoading} properties={geoJsonProperties} />
 				{/if}
 
 				<fieldset class="fieldset">

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -205,11 +205,28 @@ function proj4ToProjection() {
 	return geoProjection(project as GeoRawProjection);
 }
 
+async function getGeoJsonProperties(files: FileList): Promise<Set<string>> {
+	const properties: Set<string> = new Set<string>();
+
+	const unresolvedTexts = [];
+	for (const file of files) {
+		unresolvedTexts.push(file.text());
+	}
+
+	const resolvedTexts = await Promise.all(unresolvedTexts);
+	for (const text of resolvedTexts) {
+		Object.keys(JSON.parse(text).features[0].properties).forEach((property) => properties.add(property));
+	}
+	
+	return properties;
+}
+
 export {
 	importFromGeoJson,
 	importFromShapefiles,
 	importFromSVG,
 	newImportedMap,
 	exportImportAsSVG,
-	proj4ToProjection
+	proj4ToProjection,
+	getGeoJsonProperties
 };

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -215,9 +215,11 @@ async function getGeoJsonProperties(files: FileList): Promise<Set<string>> {
 
 	const resolvedTexts = await Promise.all(unresolvedTexts);
 	for (const text of resolvedTexts) {
-		Object.keys(JSON.parse(text).features[0].properties).forEach((property) => properties.add(property));
+		Object.keys(JSON.parse(text).features[0].properties).forEach((property) =>
+			properties.add(property)
+		);
 	}
-	
+
 	return properties;
 }
 

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -11,6 +11,8 @@ import fileSaver from 'file-saver';
 import DOMPurify from 'dompurify';
 import type { SavedRegionCandidates } from '$lib/types/Region';
 import proj4 from 'proj4';
+import { safeJsonParse } from './safeJsonParse';
+import z from 'zod';
 
 //This config allows all attributes used by the app to pass through DOMPurify without change.
 //If you are adding an attribute imported maps might need, add it here.
@@ -206,6 +208,14 @@ function proj4ToProjection() {
 }
 
 async function getGeoJsonProperties(files: FileList): Promise<Set<string>> {
+	const parser = z.object({
+		features: z.array(
+			z.object({
+				properties: z.any()
+			})
+		)
+	});
+
 	const properties: Set<string> = new Set<string>();
 
 	const unresolvedTexts = [];
@@ -215,7 +225,19 @@ async function getGeoJsonProperties(files: FileList): Promise<Set<string>> {
 
 	const resolvedTexts = await Promise.all(unresolvedTexts);
 	for (const text of resolvedTexts) {
-		Object.keys(JSON.parse(text).features[0].properties).forEach((property) =>
+		const json = safeJsonParse(text);
+		if (json.isErr()) {
+			console.error(json.error);
+			continue;
+		}
+
+		const parsedJson = parser.safeParse(json.value);
+		if (parsedJson.success === false) {
+			console.error(parsedJson.error);
+			continue;
+		}
+
+		Object.keys(parsedJson.data.features[0].properties).forEach((property) =>
 			properties.add(property)
 		);
 	}


### PR DESCRIPTION
This PR changes the GeoJsonProperties inputs from text inputs where you would input a property name to a select where you can select from each property name. I use a set to prevent duplicate property names if you are importing multiple shapefiles. My hope is this makes the feature more clear to use (and this will simplify my workflow just a tiny bit!)

![image](https://github.com/user-attachments/assets/f234b714-d612-4cce-a90b-deeaef8a2b6e)
