### PR TITLE
Add preset color selector to the edit candidate modal.

### DIFF
--- a/apps/yapms/src/lib/components/modals/NewModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/NewModalBase.svelte
@@ -36,10 +36,7 @@
 
 	$effect(() => {
 		if (open === true) dialogElement?.showModal();
-	});
-
-	$effect(() => {
-		if (open === false) dialogElement?.close();
+		else if (open === false) dialogElement?.close();
 	});
 </script>
 

--- a/apps/yapms/src/lib/components/modals/NewModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/NewModalBase.svelte
@@ -11,7 +11,7 @@
 		content = undefined,
 		action = undefined
 	}: {
-		title: string | undefined;
+		title: string;
 		open: boolean;
 		fullWidth?: boolean;
 		onClose?: (() => void) | undefined;
@@ -43,7 +43,7 @@
 <dialog class="modal modal-bottom lg:modal-middle" bind:this={dialogElement} onclose={close}>
 	<div class="modal-box flex flex-col w-full" class:!max-w-full={fullWidth}>
 		<h3 class="font-bold">
-			{title ?? ''}
+			{title}
 		</h3>
 
 		<button class="btn btn-md btn-circle btn-ghost absolute right-4 top-4" onclick={close}>

--- a/apps/yapms/src/lib/components/modals/NewModalBase.svelte
+++ b/apps/yapms/src/lib/components/modals/NewModalBase.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import XMark from '$lib/icons/XMark.svelte';
+	import type { Snippet } from 'svelte';
+
+	let {
+		title,
+		open = $bindable(false),
+		onClose = undefined,
+		fullWidth = false,
+		header = undefined,
+		content = undefined,
+		action = undefined
+	}: {
+		title: string | undefined;
+		open: boolean;
+		fullWidth?: boolean;
+		onClose?: (() => void) | undefined;
+		header?: Snippet;
+		content?: Snippet;
+		action?: Snippet;
+	} = $props();
+
+	export function close() {
+		if (onClose !== undefined) {
+			onClose();
+		} else {
+			open = false;
+		}
+	}
+
+	let contentElement: HTMLDivElement | undefined;
+	let dialogElement: HTMLDialogElement | undefined;
+	let offsetHeight: number | undefined = $state(undefined);
+
+	let isOverflow = $derived(offsetHeight && offsetHeight < (contentElement?.scrollHeight ?? 0));
+
+	$effect(() => {
+		if (open === true) dialogElement?.showModal();
+	});
+
+	$effect(() => {
+		if (open === false) dialogElement?.close();
+	});
+</script>
+
+<dialog class="modal modal-bottom lg:modal-middle" bind:this={dialogElement} onclose={close}>
+	<div class="modal-box flex flex-col w-full" class:!max-w-full={fullWidth}>
+		<h3 class="font-bold">
+			{title ?? ''}
+		</h3>
+
+		<button class="btn btn-md btn-circle btn-ghost absolute right-4 top-4" onclick={close}>
+			<XMark class="w-6 h-6" />
+		</button>
+
+		{@render header?.()}
+
+		{#if isOverflow}
+			<div class="divider pb-0 mb-0 h-0"></div>
+		{/if}
+
+		<div class="overflow-y-auto p-4" bind:this={contentElement} bind:offsetHeight>
+			{@render content?.()}
+		</div>
+
+		{#if isOverflow}
+			<div class="divider p-0 m-0 h-0"></div>
+		{/if}
+
+		<div class="modal-action">
+			{@render action?.()}
+		</div>
+	</div>
+	<form method="dialog" class="modal-backdrop">
+		<button onclick={close}>close</button>
+	</form>
+</dialog>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
@@ -13,6 +13,7 @@
 	import GenerateShades from './shadegeneration/GenerateShades.svelte';
 	import Rotate from '$lib/icons/Rotate.svelte';
 	import { flip } from 'svelte/animate';
+	import PresetColorsModal from './presetcolors/PresetColorsModal.svelte';
 
 	let newName = $state<string>('New Candidate');
 	let newDefaultValue = $state<number>(0);
@@ -20,6 +21,7 @@
 	let newColors = $state([{ color: '#000000' }]);
 
 	let colorList = $state<HTMLUListElement | undefined>(undefined);
+	let presetColorsModalIsOpen = $state(false);
 
 	useSortable(() => colorList, {
 		animation: 140,
@@ -37,8 +39,18 @@
 				return { color: presetColor };
 			});
 	});
+
 	function addColor() {
 		newColors = [...newColors, { color: '#000000' }];
+	}
+
+	function setPresetColors(margins: string[]) {
+		newColors = margins.map((margin) => {
+			return {
+				color: margin
+			};
+		});
+		presetColorsModalIsOpen = false;
 	}
 
 	function removeColor(index: number) {
@@ -58,9 +70,8 @@
 		newColors = [{ color: '#000000' }];
 	}
 
-	function selectPresetColor() {
-		$PresetColorsModalStore.open = true;
-		$AddCandidateModalStore.open = false;
+	function openPresetColorsModal() {
+		presetColorsModalIsOpen = true;
 	}
 
 	function confirm() {
@@ -145,9 +156,11 @@
 	</div>
 
 	<div slot="action" class="flex w-full gap-2">
-		<button class="btn btn-secondary" onclick={selectPresetColor}> Preset Colors </button>
+		<button class="btn btn-primary" onclick={openPresetColorsModal}> Preset Colors </button>
 		<button class="btn btn-primary" onclick={addColor}>Add Color</button>
 		<div class="grow"></div>
 		<button class="btn btn-success" onclick={confirm}>Add Candidate</button>
 	</div>
 </ModalBase>
+
+<PresetColorsModal open={presetColorsModalIsOpen} onSelectColors={setPresetColors} />

--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
@@ -13,6 +13,7 @@
 	import { preventNonNumericalInput, preventNonNumericalPaste } from '$lib/utils/inputValidation';
 	import { reorder, useSortable } from '$lib/utils/sortableHook.svelte';
 	import ModalBase from '../ModalBase.svelte';
+	import PresetColorsModal from './presetcolors/PresetColorsModal.svelte';
 	import GenerateShades from './shadegeneration/GenerateShades.svelte';
 	import { flip } from 'svelte/animate';
 
@@ -22,6 +23,7 @@
 
 	let colorList = $state<HTMLUListElement | undefined>(undefined);
 	let colorToDelete = $state<number | undefined>(undefined);
+	let presetColorsModalIsOpen = $state(false);
 
 	useSortable(() => colorList, {
 		animation: 140,
@@ -73,12 +75,24 @@
 		colorToDelete = undefined;
 	}
 
+	function openPresetColorsModal() {
+		presetColorsModalIsOpen = true;
+	}
+
 	function addColor() {
 		$CandidatesStore[candidateIndex].margins = [
 			...$CandidatesStore[candidateIndex].margins,
 			{ color: '#000000' }
 		];
 		colorToDelete = undefined;
+	}
+
+	function setPresetColors(margins: string[]) {
+		$CandidatesStore[candidateIndex].margins = margins.map((margin) => {
+			return { color: margin };
+		});
+		$RegionsStore = $RegionsStore;
+		presetColorsModalIsOpen = false;
 	}
 
 	function confirmRemove(index: number) {
@@ -177,8 +191,12 @@
 
 		<GenerateShades colorUpdater={updateColors} />
 	</div>
-	<div slot="action" class="flex flex-grow justify-between">
+	<div slot="action" class="flex flex-grow justify-between gap-2">
 		<button class="btn btn-error" onclick={deleteCandidate}>Delete Candidate</button>
-		<button class="btn btn-success" onclick={addColor}>Add Color</button>
+		<div class="grow"></div>
+		<button class="btn btn-primary" onclick={openPresetColorsModal}>Preset Colors</button>
+		<button class="btn btn-primary" onclick={addColor}>Add Color</button>
 	</div>
 </ModalBase>
+
+<PresetColorsModal bind:open={presetColorsModalIsOpen} onSelectColors={setPresetColors} />

--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/ColorButton.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/ColorButton.svelte
@@ -2,42 +2,66 @@
 	import Cog6Tooth from '$lib/icons/Cog6Tooth.svelte';
 	import MinusCircle from '$lib/icons/MinusCircle.svelte';
 
-	export let colors: string[] = [];
-	export let name: string | undefined = undefined;
+	let {
+		name,
+		colors,
+		selected,
+		hideName = false,
+		onSelect = undefined,
+		onConfirm = undefined,
+		onEdit = undefined,
+		onDelete = undefined
+	}: {
+		name: string;
+		colors: string[];
+		selected: boolean;
+		hideName?: boolean;
+		onSelect?: ((name: string) => void) | undefined;
+		onConfirm?: ((colors: string[]) => void) | undefined;
+		onEdit?: (() => void) | undefined;
+		onDelete?: (() => void) | undefined;
+	} = $props();
 
-	export let onSelect: (colors: string[]) => void;
-	export let onEdit: (() => void) | undefined = undefined;
-	export let onDelete: (() => void) | undefined = undefined;
+	function onSelectColors() {
+		onSelect?.(name ?? '');
+	}
+
+	function onConfirmColors() {
+		onConfirm?.(colors);
+	}
 </script>
 
 <div class="join">
 	{#if onEdit !== undefined}
-		<button class="btn btn-lg btn-primary join-item" on:click={onEdit}
-			><Cog6Tooth class="w-6 h-6" /></button
-		>
+		<button class="btn btn-lg btn-primary join-item" onclick={onEdit}>
+			<Cog6Tooth class="w-6 h-6" />
+		</button>
 	{/if}
 	<button
 		class="btn btn-lg join-item flex-grow flex-shrink"
-		class:h-fit={name !== undefined}
-		on:click={() => onSelect(colors)}
+		class:h-fit={name !== undefined && hideName === false}
+		onclick={onSelectColors}
 	>
 		<div class="flex flex-col py-2 items-center gap-1">
-			{#if name !== undefined}
+			{#if name !== undefined && hideName === false}
 				<h3 class="font-semibold">{name}</h3>
 			{/if}
 			<div class="flex flex-row flex-wrap gap-2">
 				{#each colors as color}
 					<div
-						class="outline outline-1 outline-white w-4 h-4 rounded-full"
+						class="outline-1 outline-white w-4 h-4 rounded-full"
 						style:background-color={color}
 					></div>
 				{/each}
 			</div>
 		</div>
 	</button>
+	{#if selected === true}
+		<button class="btn btn-primary h-auto join-item" onclick={onConfirmColors}> Confirm </button>
+	{/if}
 	{#if onDelete !== undefined}
-		<button class="btn btn-lg btn-error join-item" on:click={onDelete}
-			><MinusCircle class="w-6 h-6" /></button
-		>
+		<button class="btn btn-lg btn-error join-item" onclick={onDelete}>
+			<MinusCircle class="w-6 h-6" />
+		</button>
 	{/if}
 </div>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/presetcolors/PresetColorsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/presetcolors/PresetColorsModal.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
 	import { CustomColorsStore } from '$lib/stores/CustomColors';
 	import {
-		AddCandidateModalStore,
 		PresetColorsModalStore,
-		PresetColorsModalSelectedStore,
 		AddCustomColorModalStore,
 		EditCustomColorModalStore
 	} from '$lib/stores/Modals';
-	import ModalBase from '../../ModalBase.svelte';
+	import NewModalBase from '../../NewModalBase.svelte';
 	import ColorButton from '../customcolors/ColorButton.svelte';
 	import PresetColorsHeader from './PresetColorsHeader.svelte';
 
-	let tab = 0;
+	let {
+		open = $bindable(),
+		onSelectColors
+	}: { open: boolean; onSelectColors: (margins: string[]) => void } = $props();
+
+	let tab = $state(0);
 
 	function addCustomColor() {
 		$AddCustomColorModalStore.open = true;
@@ -31,59 +34,49 @@
 	}
 
 	function close() {
-		if ($AddCustomColorModalStore.open === true || $EditCustomColorModalStore.open === true) {
-			return;
-		}
-		$PresetColorsModalStore.open = false;
-		$AddCandidateModalStore.open = true;
-	}
-
-	function confirm(margins: string[]) {
-		$PresetColorsModalStore.open = false;
-		$PresetColorsModalSelectedStore = margins;
-		$AddCandidateModalStore.open = true;
+		open = false;
 	}
 </script>
 
-<ModalBase title="Select Preset Colors" store={PresetColorsModalStore} onClose={close}>
-	<div slot="header">
+<NewModalBase title="Select Preset Colors" {open} onClose={close}>
+	{#snippet header()}
 		<div class="flex justify-center">
 			<PresetColorsHeader bind:tab />
 		</div>
-	</div>
-	<div slot="content">
+	{/snippet}
+	{#snippet content()}
 		<div class="flex flex-col gap-2 overflow-hidden">
 			{#if tab === 0}
 				<ColorButton
 					name="Red"
 					colors={['#bf1d29', '#ff5865', '#ff8b98', '#cf8980']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Blue"
 					colors={['#1c408c', '#577ccc', '#8aafff', '#949bb3']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Green"
 					colors={['#1c8c28', '#50c85e', '#8aff97', '#7a997e']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Yellow"
 					colors={['#e6b700', '#e8c84d', '#ffe78a', '#b8a252']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Purple"
 					colors={['#822194', '#ae20c6', '#db14ff', '#a369ae']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 			{:else if tab === 1}
 				<ColorButton
 					name="Republican Presidential"
 					colors={['#800000', '#aa0000', '#d40000', '#cc2f4a', '#e27f90', '#f2b3be', '#ffccd0']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Republican Downballot"
@@ -97,12 +90,12 @@
 						'#ffc8cd',
 						'#ffe0ea'
 					]}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Democrat Presidential"
 					colors={['#002b84', '#234a99', '#466aad', '#6a89c2', '#8da8d6', '#b0c8eb', '#d3e7ff']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Democrat Downballot"
@@ -116,12 +109,12 @@
 						'#bdd3ff',
 						'#dfeeff'
 					]}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Libertarian"
 					colors={['#ce9b1e', '#deb02a', '#f1c92a', '#ffdd55', '#ffeeaa']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Independent"
@@ -136,7 +129,7 @@
 						'#f5f5f5',
 						'#fafafa'
 					]}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Write-in"
@@ -152,12 +145,12 @@
 						'#d2f7d2',
 						'#e5ffe5'
 					]}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Whig"
 					colors={['#8c2d04', '#cc4c02', '#ec7014', '#fe9929', '#fed463', '#fee391', '#fef4b4']}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 				<ColorButton
 					name="Level of support"
@@ -174,26 +167,26 @@
 						'#5d5d2d',
 						'#32320c'
 					]}
-					onSelect={confirm}
+					onSelect={onSelectColors}
 				/>
 			{:else if tab === 2}
 				{#if $CustomColorsStore.length === 0}
-					<button class="btn btn-success" on:click={addCustomColor}>Add Color</button>
+					<button class="btn btn-success" onclick={addCustomColor}>Add Color</button>
 				{/if}
 				{#each $CustomColorsStore as colors, index}
 					<ColorButton
 						{colors}
-						onSelect={confirm}
+						onSelect={onSelectColors}
 						onEdit={() => editCustomColor(index)}
 						onDelete={() => removeCustomColor(index)}
 					/>
 				{/each}
 			{/if}
 		</div>
-	</div>
-	<div slot="action">
+	{/snippet}
+	{#snippet action()}
 		{#if tab === 2 && $CustomColorsStore.length !== 0}
-			<button class="btn btn-success" on:click={addCustomColor}>Add</button>
+			<button class="btn btn-success" onclick={addCustomColor}>Add</button>
 		{/if}
-	</div>
-</ModalBase>
+	{/snippet}
+</NewModalBase>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/presetcolors/PresetColorsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/presetcolors/PresetColorsModal.svelte
@@ -12,9 +12,13 @@
 	let {
 		open = $bindable(),
 		onSelectColors
-	}: { open: boolean; onSelectColors: (margins: string[]) => void } = $props();
+	}: {
+		open: boolean;
+		onSelectColors: (margins: string[]) => void;
+	} = $props();
 
 	let tab = $state(0);
+	let selected: string | undefined = $state(undefined);
 
 	function addCustomColor() {
 		$AddCustomColorModalStore.open = true;
@@ -31,6 +35,14 @@
 		$EditCustomColorModalStore.open = true;
 		$EditCustomColorModalStore.customColorIndex = index;
 		$EditCustomColorModalStore.customColor = $CustomColorsStore.at(index) ?? [];
+	}
+
+	function onSelect(name: string) {
+		selected = name;
+	}
+
+	function onConfirm(colors: string[]) {
+		onSelectColors(colors);
 	}
 
 	function close() {
@@ -50,33 +62,45 @@
 				<ColorButton
 					name="Red"
 					colors={['#bf1d29', '#ff5865', '#ff8b98', '#cf8980']}
-					onSelect={onSelectColors}
+					selected={selected === 'Red'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Blue"
 					colors={['#1c408c', '#577ccc', '#8aafff', '#949bb3']}
-					onSelect={onSelectColors}
+					selected={selected === 'Blue'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Green"
 					colors={['#1c8c28', '#50c85e', '#8aff97', '#7a997e']}
-					onSelect={onSelectColors}
+					selected={selected === 'Green'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Yellow"
 					colors={['#e6b700', '#e8c84d', '#ffe78a', '#b8a252']}
-					onSelect={onSelectColors}
+					selected={selected === 'Yellow'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Purple"
 					colors={['#822194', '#ae20c6', '#db14ff', '#a369ae']}
-					onSelect={onSelectColors}
+					selected={selected === 'Purple'}
+					{onSelect}
+					{onConfirm}
 				/>
 			{:else if tab === 1}
 				<ColorButton
 					name="Republican Presidential"
 					colors={['#800000', '#aa0000', '#d40000', '#cc2f4a', '#e27f90', '#f2b3be', '#ffccd0']}
-					onSelect={onSelectColors}
+					selected={selected === 'Republican Presidential'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Republican Downballot"
@@ -90,12 +114,16 @@
 						'#ffc8cd',
 						'#ffe0ea'
 					]}
-					onSelect={onSelectColors}
+					selected={selected === 'Republican Downballot'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Democrat Presidential"
 					colors={['#002b84', '#234a99', '#466aad', '#6a89c2', '#8da8d6', '#b0c8eb', '#d3e7ff']}
-					onSelect={onSelectColors}
+					selected={selected === 'Democrat Presidential'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Democrat Downballot"
@@ -109,12 +137,16 @@
 						'#bdd3ff',
 						'#dfeeff'
 					]}
-					onSelect={onSelectColors}
+					selected={selected === 'Democrat Downballot'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Libertarian"
 					colors={['#ce9b1e', '#deb02a', '#f1c92a', '#ffdd55', '#ffeeaa']}
-					onSelect={onSelectColors}
+					selected={selected === 'Libertarian'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Independent"
@@ -129,7 +161,9 @@
 						'#f5f5f5',
 						'#fafafa'
 					]}
-					onSelect={onSelectColors}
+					selected={selected === 'Independent'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Write-in"
@@ -145,12 +179,16 @@
 						'#d2f7d2',
 						'#e5ffe5'
 					]}
-					onSelect={onSelectColors}
+					selected={selected === 'Write-in'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Whig"
 					colors={['#8c2d04', '#cc4c02', '#ec7014', '#fe9929', '#fed463', '#fee391', '#fef4b4']}
-					onSelect={onSelectColors}
+					selected={selected === 'Whig'}
+					{onSelect}
+					{onConfirm}
 				/>
 				<ColorButton
 					name="Level of support"
@@ -167,7 +205,9 @@
 						'#5d5d2d',
 						'#32320c'
 					]}
-					onSelect={onSelectColors}
+					selected={selected === 'Level of support'}
+					{onSelect}
+					{onConfirm}
 				/>
 			{:else if tab === 2}
 				{#if $CustomColorsStore.length === 0}
@@ -175,8 +215,12 @@
 				{/if}
 				{#each $CustomColorsStore as colors, index}
 					<ColorButton
+						name={index.toString()}
+						hideName={true}
 						{colors}
-						onSelect={onSelectColors}
+						selected={selected === index.toString()}
+						{onSelect}
+						{onConfirm}
 						onEdit={() => editCustomColor(index)}
 						onDelete={() => removeCustomColor(index)}
 					/>

--- a/apps/yapms/src/routes/app/+layout.svelte
+++ b/apps/yapms/src/routes/app/+layout.svelte
@@ -19,7 +19,6 @@
 	import EditCandidateModal from '$lib/components/modals/candidatemodal/EditCandidateModal.svelte';
 	import EditTossupModal from '$lib/components/modals/candidatemodal/EditTossupModal.svelte';
 	import AddCandidateModal from '$lib/components/modals/candidatemodal/AddCandidateModal.svelte';
-	import PresetColorsModal from '$lib/components/modals/candidatemodal/presetcolors/PresetColorsModal.svelte';
 	import AddCustomColorModal from '$lib/components/modals/candidatemodal/customcolors/AddCustomColorModal.svelte';
 	import EditCustomColorModal from '$lib/components/modals/candidatemodal/customcolors/EditCustomColorModal.svelte';
 	import ThemeModal from '$lib/components/modals/thememodal/ThemeModal.svelte';
@@ -113,8 +112,6 @@
 <EditRegionModal />
 
 <SplitRegionModal />
-
-<PresetColorsModal />
 
 <AddCustomColorModal />
 


### PR DESCRIPTION
The edit candidate modal didn't have a preset color selector.

I've made a new base modal component so it can be rendered without using a global store.

This should allow the preset color selector modal to be rendered in multiple places with its own state. So closing the preset color modal will go back to the correct previous modal.