### PR TITLE
Add no selection option to geojson imports

### DIFF
--- a/apps/yapms/src/lib/components/modals/importmodal/GeoJSONOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/GeoJSONOptions.svelte
@@ -21,6 +21,7 @@
 		{#await properties}
 			<option value="">Loading...</option>
 		{:then properties}
+			<option value="">No Selection</option>
 			{#each properties as property}
 				<option value={property}>{property}</option>
 			{/each}
@@ -36,6 +37,7 @@
 		{#await properties}
 			<option value="">Loading...</option>
 		{:then properties}
+			<option value="">No Selection</option>
 			{#each properties as property}
 				<option value={property}>{property}</option>
 			{/each}
@@ -51,6 +53,7 @@
 		{#await properties}
 			<option value="">Loading...</option>
 		{:then properties}
+			<option value="">No Selection</option>
 			{#each properties as property}
 				<option value={property}>{property}</option>
 			{/each}


### PR DESCRIPTION
This allows the ability to de-select options on the GeoJSON import modal.