### PR TITLE
Fix map search bar sizing

### DIFF
--- a/apps/yapms/src/lib/styles/global.css
+++ b/apps/yapms/src/lib/styles/global.css
@@ -27,7 +27,7 @@ body {
 	@apply flex-grow! bg-transparent!;
 }
 [data-svelte-search] input {
-	@apply input! w-full!;
+	@apply input! min-w-full;
 }
 [data-svelte-typeahead] .svelte-typeahead-list {
 	@apply mt-2! rounded-md! overflow-hidden! z-50!;


### PR DESCRIPTION
A DaisyUI change recently caused the map search bar to shrink. This PR restores it back to full width.