### PR TITLE
Fix folder arrow positioning

### DIFF
--- a/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
+++ b/apps/yapms/src/lib/components/sidebar/sections/savedmaps/SavedMapFolder.svelte
@@ -71,7 +71,7 @@
 <div class="collapse collapse-arrow bg-base-300 border-base-300 rounded-r-none">
 	<input type="checkbox" bind:checked={open} onchange={onCheck} />
 	<div
-		class="truncate collapse-title join p-0 flex items-center transition-[padding] after:mr-[calc(100%-2.5rem)] after:-mt-3.5"
+		class="truncate collapse-title join p-0 flex items-center transition-[padding] after:mr-[calc(100%-2.5rem)]"
 		class:pb-2={open}
 	>
 		<p class="truncate text-xs font-semibold pr-4 pl-8 grow text-center">{folderName}</p>


### PR DESCRIPTION
DaisyUI changed something within the collapse-arrow component and made a positioning workaround I had redundant:
<img width="350" height="70" alt="image" src="https://github.com/user-attachments/assets/a58d9325-cf15-48d4-a205-7a3eefedae9e" />

This PR removes the offending class and fixes it:
<img width="227" height="53" alt="image" src="https://github.com/user-attachments/assets/a212e255-10df-4ff9-bea1-710783de5d3d" />
