### PR TITLE
Confirmation for deleting custom color presets

### DIFF
--- a/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/ColorButton.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/customcolors/ColorButton.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import Cog6Tooth from '$lib/icons/Cog6Tooth.svelte';
 	import MinusCircle from '$lib/icons/MinusCircle.svelte';
+	import Trash from '$lib/icons/Trash.svelte';
 
 	let {
 		name,
 		colors,
 		selected,
+		deleteSelected = false,
 		hideName = false,
 		onSelect = undefined,
 		onConfirm = undefined,
@@ -15,6 +17,7 @@
 		name: string;
 		colors: string[];
 		selected: boolean;
+		deleteSelected?: boolean;
 		hideName?: boolean;
 		onSelect?: ((name: string) => void) | undefined;
 		onConfirm?: ((colors: string[]) => void) | undefined;
@@ -61,7 +64,11 @@
 	{/if}
 	{#if onDelete !== undefined}
 		<button class="btn btn-lg btn-error join-item" onclick={onDelete}>
-			<MinusCircle class="w-6 h-6" />
+			{#if deleteSelected}
+				<Trash class="w-6 h-6" />
+			{:else}
+				<MinusCircle class="w-6 h-6" />
+			{/if}
 		</button>
 	{/if}
 </div>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/presetcolors/PresetColorsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/presetcolors/PresetColorsModal.svelte
@@ -19,10 +19,20 @@
 
 	let tab = $state(0);
 	let selected: string | undefined = $state(undefined);
+	let deleteSelected: string | undefined = $state(undefined);
 
 	function addCustomColor() {
 		$AddCustomColorModalStore.open = true;
 		$PresetColorsModalStore.open = false;
+	}
+
+	function onDeleteSelected(index: number) {
+		if (deleteSelected === index.toString()) {
+			removeCustomColor(index);
+			deleteSelected = undefined;
+		} else {
+			deleteSelected = index.toString();
+		}
 	}
 
 	function removeCustomColor(index: number) {
@@ -219,10 +229,11 @@
 						hideName={true}
 						{colors}
 						selected={selected === index.toString()}
+						deleteSelected={deleteSelected === index.toString()}
 						{onSelect}
 						{onConfirm}
 						onEdit={() => editCustomColor(index)}
-						onDelete={() => removeCustomColor(index)}
+						onDelete={() => onDeleteSelected(index)}
 					/>
 				{/each}
 			{/if}


### PR DESCRIPTION
This PR adds a confirmation when you delete a custom color preset. This works just like the delete confirmation for a color in the "Edit Candidate" modal.
![colorconfirmdeletion](https://github.com/user-attachments/assets/4863a5fd-aa8e-486b-9f7a-af6f0dca7e78)

I feel like this code is structured a little weird but I think it's just a byproduct of this area of the codebase being kinda weird.