### PR TITLE
Short and long name editing

### DIFF
--- a/apps/yapms/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
+++ b/apps/yapms/src/lib/components/modals/editregionmodal/EditRegionModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import QuestionMarkCircle from '$lib/icons/QuestionMarkCircle.svelte';
 	import { EditRegionModalStore } from '$lib/stores/Modals';
 	import { RegionsStore } from '$lib/stores/regions/Regions';
 	import { preventNonNumericalInput, preventNonNumericalPaste } from '$lib/utils/inputValidation';
@@ -10,21 +11,29 @@
 	let valueInput: HTMLInputElement;
 	let valueBind = $state(0);
 
+	let shortNameBind = $state('');
+	let longNameBind = $state('');
+
+	const shortNameTooltip = 'Name used in the region tooltip';
+	const longNameTooltip = 'Name used in the edit, split, and region table modals';
+
 	$effect(() => {
 		if ($EditRegionModalStore.open) {
-			setInput();
-			focusInput();
+			setInputs();
+			focusValueInput();
 		}
 	});
 
-	function focusInput() {
+	function focusValueInput() {
 		if (valueInput) {
 			valueInput.focus();
 		}
 	}
 
-	function setInput() {
+	function setInputs() {
 		valueBind = $EditRegionModalStore.region?.value ?? 0;
+		shortNameBind = $EditRegionModalStore.region?.shortName ?? '';
+		longNameBind = $EditRegionModalStore.region?.longName ?? '';
 	}
 
 	function confirm() {
@@ -35,16 +44,21 @@
 			//Don't update value if disabled so the state stays disabled!
 			$RegionsStore[index].value = valueBind;
 		}
-		$RegionsStore[index].permaVal = valueBind;
+		$RegionsStore[index] = {
+			...$RegionsStore[index],
+			permaVal: valueBind,
+			shortName: shortNameBind,
+			longName: longNameBind
+		};
 		$EditRegionModalStore.open = false;
 	}
 </script>
 
 <ModalBase title="Edit Region {displayName} - {displayValue}" store={EditRegionModalStore}>
 	<div slot="content">
-		<fieldset class="fieldset">
-			<legend class="fieldset-legend">Region Value</legend>
-			<form onsubmit={confirm}>
+		<form onsubmit={confirm}>
+			<fieldset class="fieldset">
+				<legend class="fieldset-legend">Region Value</legend>
 				<input
 					type="number"
 					class="input input-bordered w-full"
@@ -54,8 +68,33 @@
 					bind:value={valueBind}
 					bind:this={valueInput}
 				/>
-			</form>
-		</fieldset>
+
+				<div class="md:flex gap-x-2">
+					<div class="w-full">
+						<legend class="fieldset-legend flex justify-start gap-x-1">
+							Short Name
+							<div class="tooltip tooltip-top before:max-w-[24ch]" data-tip={shortNameTooltip}>
+								<QuestionMarkCircle class="w-5" />
+							</div>
+						</legend>
+						<input type="text" class="input input-bordered w-full" bind:value={shortNameBind} />
+					</div>
+
+					<div class="w-full">
+						<legend class="fieldset-legend flex justify-start gap-x-1">
+							Long Name
+							<div class="tooltip tooltip-top before:max-w-[24ch]" data-tip={longNameTooltip}>
+								<QuestionMarkCircle class="w-5" />
+							</div>
+						</legend>
+						<input type="text" class="input input-bordered w-full" bind:value={longNameBind} />
+					</div>
+				</div>
+
+				<!-- Hidden button so you can hit enter to submit form -->
+				<button type="submit" hidden>Submit</button>
+			</fieldset>
+		</form>
 	</div>
 	<div slot="action">
 		<button class="btn btn-success" onclick={confirm}>Confirm</button>

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -218,6 +218,8 @@ function exportImportAsSVG(): void {
 			});
 			region.nodes.region.setAttribute('candidates', JSON.stringify(candidateAttr));
 			region.nodes.region.setAttribute('value', region.permaVal.toString());
+			region.nodes.region.setAttribute('short-name', region.shortName.toString());
+			region.nodes.region.setAttribute('long-name', region.longName.toString());
 			if (region.disabled) {
 				region.nodes.region.setAttribute('disabled', region.disabled.toString());
 			}


### PR DESCRIPTION
This PR adds inputs in the edit region modal that allow people to change the `short-name` and `long-name` properties for their custom maps without having to go into Inkscape or a text editor. It also enables changes in those properties to be reflected in an exported SVG.