### PR TITLE
Disable in fill mode

### DIFF
--- a/apps/yapms/src/lib/stores/regions/Regions.ts
+++ b/apps/yapms/src/lib/stores/regions/Regions.ts
@@ -290,8 +290,14 @@ export const setPointerEvents = (): void => {
 
 			const currentMode = get(ModeStore);
 			const currentInteractions = get(InteractionStore);
-			if (currentMode === 'fill' && currentInteractions.has('KeyF')) {
-				fillRegion(region.id, false);
+			if (currentInteractions.has('KeyF')) {
+				switch (currentMode) {
+					case 'fill':
+						fillRegion(region.id, false);
+						break;
+					case 'disable':
+						disableRegion(region.id, true);
+				}
 			}
 		};
 

--- a/apps/yapms/src/lib/stores/regions/regionActions.ts
+++ b/apps/yapms/src/lib/stores/regions/regionActions.ts
@@ -118,11 +118,11 @@ export function editRegion(regionID: string): void {
 	});
 }
 
-export function disableRegion(regionID: string) {
+export function disableRegion(regionID: string, onlyDisable: boolean = false) {
 	const regions = get(RegionsStore);
 	const region = regions.find((region) => region.id === regionID);
 	if (region) {
-		if (region?.disabled) {
+		if (region?.disabled && !onlyDisable) {
 			region.disabled = false;
 			region.value = region.permaVal;
 		} else {


### PR DESCRIPTION
This PR allows holding "F" to disable filling regions. I get around the problem of disabling and re-enabling as you drag your mouse around by only having it disable when F is held down, not re-enable.