### PR TITLE
Automatically center & rotate imported maps when using built-in projection options

### DIFF
--- a/apps/yapms/src/lib/components/modals/importmodal/ProjectionOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ProjectionOptions.svelte
@@ -39,7 +39,11 @@
 	{#if $ImportedSVGStore.options.projectionFunction !== proj4ToProjection}
 		<fieldset class="fieldset">
 			<label class="fieldset-label">
-				<input type="checkbox" class="toggle toggle-xs" bind:checked={$ImportedSVGStore.options.rotateAndCenter} />
+				<input
+					type="checkbox"
+					class="toggle toggle-xs"
+					bind:checked={$ImportedSVGStore.options.rotateAndCenter}
+				/>
 				Rotate and Center Projection
 			</label>
 		</fieldset>

--- a/apps/yapms/src/lib/components/modals/importmodal/ProjectionOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ProjectionOptions.svelte
@@ -36,7 +36,15 @@
 			<option value={projection.projectionFunction}>{projection.label}</option>
 		{/each}
 	</select>
-	{#if $ImportedSVGStore.options.projectionFunction == proj4ToProjection}
+	{#if $ImportedSVGStore.options.projectionFunction !== proj4ToProjection}
+		<fieldset class="fieldset">
+			<label class="fieldset-label">
+				<input type="checkbox" class="toggle toggle-xs" bind:checked={$ImportedSVGStore.options.rotateAndCenter} />
+				Rotate and Center Projection
+			</label>
+		</fieldset>
+	{/if}
+	{#if $ImportedSVGStore.options.projectionFunction === proj4ToProjection}
 		<input
 			type="text"
 			class="input input-bordered w-full"

--- a/apps/yapms/src/lib/stores/ImportedSVG.ts
+++ b/apps/yapms/src/lib/stores/ImportedSVG.ts
@@ -10,6 +10,7 @@ export const ImportedSVGStore = writable<ImportedSVG>({
 	content: '',
 	options: {
 		projectionFunction: geoMercator,
+		rotateAndCenter: true,
 		crsDefinition: '',
 		customProjectionDefinition: '',
 		shortNameProp: '',

--- a/apps/yapms/src/lib/types/ImportedSVG.ts
+++ b/apps/yapms/src/lib/types/ImportedSVG.ts
@@ -5,6 +5,7 @@ export type ImportedSVG = {
 	content: string;
 	options: {
 		projectionFunction: () => GeoProjection;
+		rotateAndCenter: boolean;
 		customProjectionDefinition: string;
 		crsDefinition: string;
 		shortNameProp: string;

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -1,7 +1,7 @@
 import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 import { ImportModalStore } from '$lib/stores/Modals';
 import rewind from '@turf/rewind';
-import { geoBounds, geoPath, geoProjection, type GeoRawProjection } from 'd3';
+import { geoBounds, geoCentroid, geoPath, geoProjection, type GeoRawProjection } from 'd3';
 import * as shapefile from 'shapefile';
 import { degreesToRadians, type AllGeoJSON, radiansToDegrees } from '@turf/helpers';
 import { get } from 'svelte/store';
@@ -151,12 +151,8 @@ function geoJsonToSVG(districtShapes: GeoJSON.FeatureCollection) {
 	let projection = importOptions.projectionFunction();
 
 	if (importOptions.rotateAndCenter && importOptions.projectionFunction !== proj4ToProjection && projection.rotate !== undefined && projection.center !== undefined) {
-		const [[x0, y0], [x1, y1]] = geoBounds(districtShapes);
-
-		const centerLat = (y0 + y1) / 2;
-		const centerLon = (x0 + x1) / 2;
-
-		projection = projection.rotate([-centerLon, 0]).center([0, centerLat]);
+		const centroid = geoCentroid(districtShapes);
+		projection = projection.rotate([-centroid[0], 0]);
 	}
 
 	projection = projection.fitSize([width, height], districtShapes);

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -150,7 +150,12 @@ function geoJsonToSVG(districtShapes: GeoJSON.FeatureCollection) {
 
 	let projection = importOptions.projectionFunction();
 
-	if (importOptions.rotateAndCenter && importOptions.projectionFunction !== proj4ToProjection && projection.rotate !== undefined && projection.center !== undefined) {
+	if (
+		importOptions.rotateAndCenter &&
+		importOptions.projectionFunction !== proj4ToProjection &&
+		projection.rotate !== undefined &&
+		projection.center !== undefined
+	) {
 		const centroid = geoCentroid(districtShapes);
 		projection = projection.rotate([-centroid[0], -centroid[1]]);
 	}

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -1,7 +1,7 @@
 import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 import { ImportModalStore } from '$lib/stores/Modals';
 import rewind from '@turf/rewind';
-import { geoBounds, geoCentroid, geoPath, geoProjection, type GeoRawProjection } from 'd3';
+import { geoCentroid, geoPath, geoProjection, type GeoRawProjection } from 'd3';
 import * as shapefile from 'shapefile';
 import { degreesToRadians, type AllGeoJSON, radiansToDegrees } from '@turf/helpers';
 import { get } from 'svelte/store';

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -1,7 +1,7 @@
 import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 import { ImportModalStore } from '$lib/stores/Modals';
 import rewind from '@turf/rewind';
-import { geoPath, geoProjection, type GeoRawProjection } from 'd3';
+import { geoBounds, geoPath, geoProjection, type GeoRawProjection } from 'd3';
 import * as shapefile from 'shapefile';
 import { degreesToRadians, type AllGeoJSON, radiansToDegrees } from '@turf/helpers';
 import { get } from 'svelte/store';
@@ -148,7 +148,18 @@ function geoJsonToSVG(districtShapes: GeoJSON.FeatureCollection) {
 		);
 	}
 
-	const projection = importOptions.projectionFunction().fitSize([width, height], districtShapes);
+	let projection = importOptions.projectionFunction();
+
+	if (importOptions.rotateAndCenter && importOptions.projectionFunction !== proj4ToProjection && projection.rotate !== undefined && projection.center !== undefined) {
+		const [[x0, y0], [x1, y1]] = geoBounds(districtShapes);
+
+		const centerLat = (y0 + y1) / 2;
+		const centerLon = (x0 + x1) / 2;
+
+		projection = projection.rotate([-centerLon, 0]).center([0, centerLat]);
+	}
+
+	projection = projection.fitSize([width, height], districtShapes);
 
 	const render = geoPath().projection(projection);
 

--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -152,7 +152,7 @@ function geoJsonToSVG(districtShapes: GeoJSON.FeatureCollection) {
 
 	if (importOptions.rotateAndCenter && importOptions.projectionFunction !== proj4ToProjection && projection.rotate !== undefined && projection.center !== undefined) {
 		const centroid = geoCentroid(districtShapes);
-		projection = projection.rotate([-centroid[0], 0]);
+		projection = projection.rotate([-centroid[0], -centroid[1]]);
 	}
 
 	projection = projection.fitSize([width, height], districtShapes);


### PR DESCRIPTION
This PR adds a option to the custom map dialog that centers and rotates imported maps when using the built-in projection options. 

<img width="461" height="121" alt="image" src="https://github.com/user-attachments/assets/bd680fcc-06c6-495e-a3eb-6fb85c25ec55" />

I set the option to be enabled by default as I would define having the map upright and centered as the expected behavior.

This option is not used and not shown when a custom projection is being used - those will have their own rotations and centerings and having the option enabled for custom projections results in wrongly rotated maps.

Example without setting:
<img width="428" height="383" alt="image" src="https://github.com/user-attachments/assets/6585273c-7901-4529-bb0c-c096688951d1" />

Example with:
<img width="442" height="376" alt="image" src="https://github.com/user-attachments/assets/390cd64b-e79d-4617-b197-2e99f0faf022" />

