### PR TITLE
Fix lint and check

### DIFF
--- a/apps/yapms/package.json
+++ b/apps/yapms/package.json
@@ -42,6 +42,7 @@
 		"eslint-plugin-svelte": "3.15.0",
 		"file-saver": "2.0.5",
 		"glob": "13.0.6",
+		"globals": "17.3.0",
 		"html-to-image": "1.11.13",
 		"neverthrow": "8.2.0",
 		"panzoom": "9.4.3",

--- a/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
+++ b/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
@@ -225,8 +225,7 @@
 					<button
 						class="btn btn-primary"
 						onclick={generateLink}
-						disabled={fetchingLink ||
-							turnstileToken === null}
+						disabled={fetchingLink || turnstileToken === null}
 					>
 						<Link class="w-5 h-5" />
 						<span>Generate a link to share with others!</span>

--- a/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
+++ b/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
@@ -227,7 +227,7 @@
 						onclick={generateLink}
 						disabled={fetchingLink ||
 							turnstileToken === null ||
-							page.url.pathname === '/app/imported'}
+							String(page.url.pathname) === '/app/imported'}
 					>
 						<Link class="w-5 h-5" />
 						<span>Generate a link to share with others!</span>

--- a/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
+++ b/apps/yapms/src/lib/components/modals/sharemodal/ShareModal.svelte
@@ -226,8 +226,7 @@
 						class="btn btn-primary"
 						onclick={generateLink}
 						disabled={fetchingLink ||
-							turnstileToken === null ||
-							String(page.url.pathname) === '/app/imported'}
+							turnstileToken === null}
 					>
 						<Link class="w-5 h-5" />
 						<span>Generate a link to share with others!</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-plugin-svelte": "3.15.0",
         "file-saver": "2.0.5",
         "glob": "13.0.6",
+        "globals": "17.3.0",
         "html-to-image": "1.11.13",
         "neverthrow": "8.2.0",
         "panzoom": "9.4.3",
@@ -5388,6 +5389,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {


### PR DESCRIPTION
Installed the global package... either it's newly required by an update or it got deleted?

Also fixed an string comparison. Svelte changed the type of the pathname variable, but it's not properly detecting that /app/imported is a valid path in yapms.
