### PR TITLE
Mass disable, enable, lock, & unlock

### DIFF
--- a/apps/yapms/src/lib/components/modals/toolsmodal/ToolButton.svelte
+++ b/apps/yapms/src/lib/components/modals/toolsmodal/ToolButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { ToolsModalStore } from '$lib/stores/Modals';
 
-	const { text, callback } = $props();
+	const { text, callback }: { text: string; callback: () => void } = $props();
 </script>
 
 <button

--- a/apps/yapms/src/lib/components/modals/toolsmodal/ToolButton.svelte
+++ b/apps/yapms/src/lib/components/modals/toolsmodal/ToolButton.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
 	import { ToolsModalStore } from '$lib/stores/Modals';
-	import type { Writable } from 'svelte/store';
 
 	export let text: string;
-	export let store: Writable<{ open: boolean }>;
-
-	function openToolModal() {
-		$store.open = true;
-		$ToolsModalStore.open = false;
-	}
+	export let callback: () => void;
 </script>
 
-<button class="btn btn-primary" on:click={openToolModal}>
+<button
+	class="btn btn-primary"
+	on:click={() => {
+		callback();
+		$ToolsModalStore.open = false;
+	}}
+>
 	{text}
 </button>

--- a/apps/yapms/src/lib/components/modals/toolsmodal/ToolButton.svelte
+++ b/apps/yapms/src/lib/components/modals/toolsmodal/ToolButton.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import { ToolsModalStore } from '$lib/stores/Modals';
 
-	export let text: string;
-	export let callback: () => void;
+	const { text, callback } = $props();
 </script>
 
 <button
 	class="btn btn-primary"
-	on:click={() => {
+	onclick={() => {
 		callback();
 		$ToolsModalStore.open = false;
 	}}

--- a/apps/yapms/src/lib/components/modals/toolsmodal/ToolsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/toolsmodal/ToolsModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { MassEditModalStore, TableModalStore, ToolsModalStore } from '$lib/stores/Modals';
+	import { disableAll, enableAll, lockAll, unlockAll } from '$lib/stores/regions/regionActions';
 	import ModalBase from '../ModalBase.svelte';
 	import ToolButton from './ToolButton.svelte';
 	import MassEditModal from './tools/MassEditModal.svelte';
@@ -9,8 +10,16 @@
 <ModalBase title="Tools" store={ToolsModalStore}>
 	<div slot="content">
 		<div class="flex flex-col gap-y-2 mx-5">
-			<ToolButton text="Regions Table" store={TableModalStore} />
-			<ToolButton text="Edit All Regions" store={MassEditModalStore} />
+			<ToolButton text="Regions Table" callback={() => ($TableModalStore.open = true)} />
+			<ToolButton text="Edit All" callback={() => ($MassEditModalStore.open = true)} />
+			<div class="flex flex-row gap-x-2 [&>*]:flex-1">
+				<ToolButton text="Disable All" callback={disableAll} />
+				<ToolButton text="Enable All" callback={enableAll} />
+			</div>
+			<div class="flex flex-row gap-x-2 [&>*]:flex-1">
+				<ToolButton text="Lock All" callback={lockAll} />
+				<ToolButton text="Unlock All" callback={unlockAll} />
+			</div>
 		</div>
 	</div>
 </ModalBase>

--- a/apps/yapms/src/lib/stores/regions/regionActions.ts
+++ b/apps/yapms/src/lib/stores/regions/regionActions.ts
@@ -163,6 +163,24 @@ export function disableNotGroup(group: number, subgroup: number) {
 	RegionsStore.set(regions);
 }
 
+export function disableAll() {
+	const regions = get(RegionsStore);
+	regions.forEach((region) => {
+		region.disabled = true;
+		region.value = 0;
+	});
+	RegionsStore.set(regions);
+}
+
+export function enableAll() {
+	const regions = get(RegionsStore);
+	regions.forEach((region) => {
+		region.disabled = false;
+		region.value = region.permaVal;
+	});
+	RegionsStore.set(regions);
+}
+
 export function lockRegion(regionID: string) {
 	const regions = get(RegionsStore);
 	const region = regions.find((region) => region.id === regionID);
@@ -187,5 +205,17 @@ export function lockNotGroup(group: number, subgroup: number) {
 		if (region.actionGroups.at(group) === subgroup) continue;
 		region.locked = !region.locked;
 	}
+	RegionsStore.set(regions);
+}
+
+export function lockAll() {
+	const regions = get(RegionsStore);
+	regions.forEach((region) => (region.locked = true));
+	RegionsStore.set(regions);
+}
+
+export function unlockAll() {
+	const regions = get(RegionsStore);
+	regions.forEach((region) => (region.locked = false));
 	RegionsStore.set(regions);
 }


### PR DESCRIPTION
This PR adds new functionality to the Tools modal allowing you to disable, enable, lock, and unlock all regions at once.

![massDisableYAPms](https://github.com/user-attachments/assets/bdba95b1-f78d-4099-9638-b2936ee6fe78)

To achieve this, I modify ToolButtons to accept a callback and then pass in functions defined in regionActions.
