### PR TITLE
Remove stale disabled & locked DOM attributes on export

### DIFF
--- a/apps/yapms/src/lib/utils/importMap.ts
+++ b/apps/yapms/src/lib/utils/importMap.ts
@@ -232,6 +232,9 @@ function exportImportAsSVG(): void {
 			region.nodes.region.setAttribute('value', region.permaVal.toString());
 			region.nodes.region.setAttribute('short-name', region.shortName.toString());
 			region.nodes.region.setAttribute('long-name', region.longName.toString());
+
+			region.nodes.region.removeAttribute('disabled');
+			region.nodes.region.removeAttribute('locked');
 			if (region.disabled) {
 				region.nodes.region.setAttribute('disabled', region.disabled.toString());
 			}


### PR DESCRIPTION
This PR fixes an issue where if a map was saved as SVG twice, once with a region disabled and after with that region not disabled, the value for the disabled attribute set in the first export would erroneously stick around on that region and the second exported map would show the region as being disabled when loaded.