### PR TITLE
Arch Chart

### DIFF
--- a/apps/yapms/src/lib/components/chartarea/ChartArea.svelte
+++ b/apps/yapms/src/lib/components/chartarea/ChartArea.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ChartTypeStore, ChartPositionStore } from '$lib/stores/Chart';
 	import { LogoStore } from '$lib/stores/Logo';
+	import ArchChart from '../charts/archchart/ArchChart.svelte';
 	import BattleChart from '../charts/battlechart/BattleChart.svelte';
 	import CircleChart from '../charts/circlechart/CircleChart.svelte';
 
@@ -29,7 +30,9 @@
 	class:w-96={$ChartPositionStore === 'left' && $ChartTypeStore !== 'battle'}
 	class:h-80={$ChartPositionStore === 'bottom' && $ChartTypeStore !== 'battle'}
 >
-	{#if $ChartTypeStore === 'battle'}
+	{#if $ChartTypeStore === 'arch'}
+		<ArchChart />
+	{:else if $ChartTypeStore === 'battle'}
 		<BattleChart />
 	{:else if $ChartTypeStore === 'pie'}
 		<CircleChart type="pie" />

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -68,16 +68,11 @@
 
 	const width = $derived(rows * 2 * rowHeight);
 
-	let points = $state<{ radius: number; theta: number }[]>();
-
-	$effect(() => {
-		// Determine point positions
-		const rows = getRowsFromSeats(numSeats);
-
+	const points = $derived.by(() => {
 		let pointIdx = 0;
 		const unsortedPoints = [];
 
-		for (let i = startingRow; i <= rows && pointIdx < numSeats; i++) {
+		for (let i = startingRow; i < rows && pointIdx < numSeats; i++) {
 			let numInRow = Math.round(fillFactor * dotsOnRow(i));
 			numInRow = Math.min(numInRow, numSeats - pointIdx);
 			// Put all remaining seats lost in rounding on the outside row
@@ -100,7 +95,7 @@
 		}
 
 		// Sort large radius to small radius and then small angle to large angle from beginning
-		points = unsortedPoints.sort((a, b) => a.radius - b.radius).sort((a, b) => a.theta - b.theta);
+		return unsortedPoints.sort((a, b) => a.radius - b.radius).sort((a, b) => a.theta - b.theta);
 	});
 
 	function getRowsFromSeats(targetSeats: number) {

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -47,6 +47,23 @@
 
 	const rows = $derived(getRowsFromSeats(numSeats));
 
+	const maxForRows = $derived(getSeatsFromRow(rows));
+
+	const startingRow = $derived.by(() => {
+		let starter = 1;
+		let spotsRemoved = 0;
+
+		while (maxForRows-(getSeatsFromRow(starter+1) + spotsRemoved) >= numSeats) {
+			starter++;
+			spotsRemoved += getSeatsFromRow(starter+1);
+		}
+		return starter;
+	});
+
+	const actualSpots = $derived(maxForRows - getSeatsFromRow(startingRow));
+
+	const fillFactor = $derived(numSeats/actualSpots);
+
 	const width = $derived(rows * 2 * rowHeight);
 
 	let points = $state<{ radius: number; theta: number }[]>();
@@ -57,9 +74,18 @@
 
 		let pointIdx = 0;
 		const unsortedPoints = [];
-		for (let i = rows; i > 0 && pointIdx < numSeats; i--) {
-			let numInRow = dotsOnRow(i);
+
+		console.log("max for rows", maxForRows)
+		console.log("starting row", startingRow)
+		console.log("fill factor", fillFactor)
+		console.log("actual spots", actualSpots)
+		console.log("num needed", numSeats)
+
+		for (let i = startingRow; i < rows && pointIdx < numSeats; i++) {
+			let numInRow = Math.round(fillFactor*dotsOnRow(i));
 			numInRow = Math.min(numInRow, numSeats - pointIdx);
+
+			if (i === rows-1) numInRow = numSeats - pointIdx;
 
 			const radius = i * rowHeight;
 			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {
@@ -89,6 +115,16 @@
 			rows++;
 		}
 		return rows;
+	}
+
+	function getSeatsFromRow(targetRows: number) {
+		let rows = 0;
+		let seats = 0;
+		while (rows < targetRows) {
+			seats += dotsOnRow(rows);
+			rows++;
+		}
+		return seats;
 	}
 
 	function dotsOnRow(nRow: number) {

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -75,8 +75,6 @@
 		for (let i = startingRow; i < rows && pointIdx < numSeats; i++) {
 			let numInRow = Math.round(fillFactor * dotsOnRow(i));
 			numInRow = Math.min(numInRow, numSeats - pointIdx);
-			// Put all remaining seats lost in rounding on the outside row
-			if (i === rows) numInRow = numSeats - pointIdx;
 
 			const radius = i * rowHeight;
 			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -61,13 +61,7 @@
 
 		// Determine point colors
 		const pointColors = $ChartLeansStore.enabled
-			? arrangedCandidates.flatMap((c) =>
-					$CandidateCountsMargins.get(c.id) !== undefined
-						? $CandidateCountsMargins
-								.get(c.id)!
-								.flatMap((m, i) => Array(m).fill(c.margins[i].color))
-						: []
-				)
+			? getPointColorsWithMargins()
 			: arrangedCandidates.flatMap((c) =>
 					Array($CandidateCounts.get(c.id)).fill(c.margins[0].color)
 				);
@@ -101,6 +95,20 @@
 		const arcRad = nRow * rowHeight;
 
 		return Math.floor((2 * Math.PI * arcRad) / (2 * rowHeight));
+	}
+
+	function getPointColorsWithMargins() {
+		const colors = arrangedCandidates.map((c) =>
+			$CandidateCountsMargins.get(c.id) !== undefined
+				? $CandidateCountsMargins.get(c.id)!.flatMap((m, i) => Array(m).fill(c.margins[i].color))
+				: []
+		);
+
+		if (arrangedCandidates.length === 3) {
+			colors[2].reverse();
+		}
+
+		return colors.flat();
 	}
 </script>
 

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -75,6 +75,8 @@
 		for (let i = startingRow; i < rows && pointIdx < numSeats; i++) {
 			let numInRow = Math.round(fillFactor * dotsOnRow(i));
 			numInRow = Math.min(numInRow, numSeats - pointIdx);
+			// Put all remaining seats lost in rounding on the outside row
+			if (i === rows-1) numInRow = numSeats - pointIdx;
 
 			const radius = i * rowHeight;
 			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -76,7 +76,7 @@
 			let numInRow = Math.round(fillFactor * dotsOnRow(i));
 			numInRow = Math.min(numInRow, numSeats - pointIdx);
 			// Put all remaining seats lost in rounding on the outside row
-			if (i === rows-1) numInRow = numSeats - pointIdx;
+			if (i === rows - 1) numInRow = numSeats - pointIdx;
 
 			const radius = i * rowHeight;
 			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -23,11 +23,33 @@
 		...candidatesWithCounts.slice(Math.ceil(candidatesWithCounts.length / 2))
 	]);
 
+	const pointColors = $derived.by(() => {
+		if (!$ChartLeansStore.enabled) {
+			return arrangedCandidates.flatMap((c) =>
+				Array($CandidateCounts.get(c.id)).fill(c.margins[0].color)
+			);
+		}
+
+		const colors = arrangedCandidates.map((c) =>
+			$CandidateCountsMargins.get(c.id) !== undefined
+				? $CandidateCountsMargins.get(c.id)!.flatMap((m, i) => Array(m).fill(c.margins[i].color))
+				: []
+		);
+
+		if (arrangedCandidates.length === 3) {
+			colors[2].reverse();
+		}
+
+		return colors.flat();
+	});
+
 	const numSeats = $derived([...$CandidateCounts.values()].reduce((total, cur) => total + cur, 0));
 
-	const width = $derived(getWidthFromSeats(numSeats));
+	const rows = $derived(getRowsFromSeats(numSeats));
 
-	let points = $state<{ r: number; theta: number; color: string }[]>();
+	const width = $derived(rows * 2 * rowHeight);
+
+	let points = $state<{ radius: number; theta: number }[]>();
 
 	$effect(() => {
 		// Determine point positions
@@ -41,45 +63,23 @@
 
 			const radius = i * rowHeight;
 			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {
-				// Determine position on the unit circle. Add 0.5 to j to rest on the upper semicircle
-				let radians = ((j + 0.5) * Math.PI) / numInRow;
+				// Determine position along the top half of the unit circle.
+				const percentageAlongSemicircle = (j / numInRow);
+				//Adjust to the midpoint of the interval from [i/numInRow, i+1/numInRow]. e.x: [0, 0.5] becomes [0.25, 0.75] for 2 points
+				const midpointOffset = (0.5 / numInRow);
 
-				// If point on the circle will end up on the lower semicircle, bring it back around to the upper semicircle
-				if (radians > Math.PI) {
-					radians += Math.PI;
-				}
+				const theta = (percentageAlongSemicircle + midpointOffset) * Math.PI;
 
 				// Append position of circle in polar coordinates.
-				unsortedPoints.push({ r: radius, theta: radians, color: '' });
+				unsortedPoints.push({ radius, theta });
 
 				pointIdx++;
 			}
 		}
 
 		// Sort large radius to small radius and then small angle to large angle from beginning
-		const sortedPoints = unsortedPoints.sort((a, b) => a.r - b.r).sort((a, b) => a.theta - b.theta);
-
-		// Determine point colors
-		const pointColors = $ChartLeansStore.enabled
-			? getPointColorsWithMargins()
-			: arrangedCandidates.flatMap((c) =>
-					Array($CandidateCounts.get(c.id)).fill(c.margins[0].color)
-				);
-
-		sortedPoints.forEach((point, i) => (point.color = pointColors[i]));
-
-		points = sortedPoints;
+		points = unsortedPoints.sort((a, b) => a.radius - b.radius).sort((a, b) => a.theta - b.theta);
 	});
-
-	function getWidthFromSeats(targetSeats: number) {
-		let rows = 0;
-		let seats = 0;
-		while (seats < targetSeats) {
-			seats += dotsOnRow(rows);
-			rows++;
-		}
-		return rows * (2 * rowHeight);
-	}
 
 	function getRowsFromSeats(targetSeats: number) {
 		let rows = 0;
@@ -96,20 +96,6 @@
 
 		return Math.floor((2 * Math.PI * arcRad) / (2 * rowHeight));
 	}
-
-	function getPointColorsWithMargins() {
-		const colors = arrangedCandidates.map((c) =>
-			$CandidateCountsMargins.get(c.id) !== undefined
-				? $CandidateCountsMargins.get(c.id)!.flatMap((m, i) => Array(m).fill(c.margins[i].color))
-				: []
-		);
-
-		if (arrangedCandidates.length === 3) {
-			colors[2].reverse();
-		}
-
-		return colors.flat();
-	}
 </script>
 
 <div
@@ -117,18 +103,22 @@
 	class:h-full={$ChartPositionStore === 'bottom'}
 	class:w-full={$ChartPositionStore === 'left'}
 >
-	<div class="w-full h-full">
+	<div class="flex w-full h-full">
 		<svg
 			viewBox={`-${width / 2 + seatRadius} -${width / 2 + seatRadius} ${width + seatRadius * 2} ${width / 2 + seatRadius * 2}`}
 		>
-			{#each points as point}
+			{#each points as point, idx}
 				<circle
 					r={seatRadius}
-					fill={point.color}
-					cy={point.r * Math.sin(point.theta) * -1}
-					cx={point.r * Math.cos(point.theta) * -1}
+					fill={pointColors[idx]}
+					cy={point.radius * Math.sin(point.theta) * -1}
+					cx={point.radius * Math.cos(point.theta) * -1}
 				></circle>
 			{/each}
 		</svg>
+		{#each Array(rows).keys() as row}
+			{dotsOnRow(row)}
+			<br>
+		{/each}
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { CandidatesStore, TossupCandidateStore } from '$lib/stores/Candidates';
+	import { CandidateCounts, CandidateCountsMargins } from '$lib/stores/regions/Regions';
+	import { ChartPositionStore } from '$lib/stores/Chart';
+	import { ChartLeansStore } from '$lib/stores/ChartLeansStore';
+
+	const seatRadius = 6;
+
+	const marginBetweenSeats = 2;
+
+	const rowHeight = marginBetweenSeats + seatRadius * 2;
+
+	const candidatesWithCounts = $derived(
+		$CandidatesStore.filter(
+			(c) => $CandidateCounts.get(c.id) !== undefined && $CandidateCounts.get(c.id) !== 0
+		)
+	);
+
+	// Arrange candidates half on one side, half on the other, with tossup in the middle.
+	const arrangedCandidates = $derived([
+		...candidatesWithCounts.slice(0, Math.ceil(candidatesWithCounts.length / 2)),
+		$TossupCandidateStore,
+		...candidatesWithCounts.slice(Math.ceil(candidatesWithCounts.length / 2))
+	]);
+
+	const numSeats = $derived([...$CandidateCounts.values()].reduce((total, cur) => total + cur, 0));
+
+	const width = $derived(getWidthFromSeats(numSeats));
+
+	let points = $state<{ r: number; theta: number; color: string }[]>();
+
+	$effect(() => {
+		// Determine point positions
+		const rows = getRowsFromSeats(numSeats);
+
+		let pointIdx = 0;
+		const unsortedPoints = [];
+		for (let i = rows; i > 0 && pointIdx < numSeats; i--) {
+			let numInRow = dotsOnRow(i);
+			numInRow = Math.min(numInRow, numSeats - pointIdx);
+
+			const radius = i * rowHeight;
+			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {
+				// Determine position on the unit circle. Add 0.5 to j to rest on the upper semicircle
+				let radians = ((j + 0.5) * Math.PI) / numInRow;
+
+				// If point on the circle will end up on the lower semicircle, bring it back around to the upper semicircle
+				if (radians > Math.PI) {
+					radians += Math.PI;
+				}
+
+				// Append position of circle in polar coordinates.
+				unsortedPoints.push({ r: radius, theta: radians, color: '' });
+
+				pointIdx++;
+			}
+		}
+
+		// Sort large radius to small radius and then small angle to large angle from beginning
+		const sortedPoints = unsortedPoints.sort((a, b) => a.r - b.r).sort((a, b) => a.theta - b.theta);
+
+		// Determine point colors
+		const pointColors = $ChartLeansStore.enabled
+			? arrangedCandidates.flatMap((c) =>
+					$CandidateCountsMargins.get(c.id) !== undefined
+						? $CandidateCountsMargins
+								.get(c.id)!
+								.flatMap((m, i) => Array(m).fill(c.margins[i].color))
+						: []
+				)
+			: arrangedCandidates.flatMap((c) =>
+					Array($CandidateCounts.get(c.id)).fill(c.margins[0].color)
+				);
+
+		sortedPoints.forEach((point, i) => (point.color = pointColors[i]));
+
+		points = sortedPoints;
+	});
+
+	function getWidthFromSeats(targetSeats: number) {
+		let rows = 0;
+		let seats = 0;
+		while (seats < targetSeats) {
+			seats += dotsOnRow(rows);
+			rows++;
+		}
+		return rows * (2 * rowHeight);
+	}
+
+	function getRowsFromSeats(targetSeats: number) {
+		let rows = 0;
+		let seats = 0;
+		while (seats < targetSeats) {
+			seats += dotsOnRow(rows);
+			rows++;
+		}
+		return rows;
+	}
+
+	function dotsOnRow(nRow: number) {
+		const arcRad = nRow * rowHeight;
+
+		return Math.floor((2 * Math.PI * arcRad) / (2 * rowHeight));
+	}
+</script>
+
+<div
+	class="flex justify-center items-center min-w-0 aspect-2/1"
+	class:h-full={$ChartPositionStore === 'bottom'}
+	class:w-full={$ChartPositionStore === 'left'}
+>
+	<div class="w-full h-full">
+		<svg
+			viewBox={`-${width / 2 + seatRadius} -${width / 2 + seatRadius} ${width + seatRadius * 2} ${width / 2 + seatRadius * 2}`}
+		>
+			{#each points as point}
+				<circle
+					r={seatRadius}
+					fill={point.color}
+					cy={point.r * Math.sin(point.theta) * -1}
+					cx={point.r * Math.cos(point.theta) * -1}
+				></circle>
+			{/each}
+		</svg>
+	</div>
+</div>

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -45,7 +45,8 @@
 
 	const numSeats = $derived([...$CandidateCounts.values()].reduce((total, cur) => total + cur, 0));
 
-	const rows = $derived(getRowsFromSeats(numSeats));
+	// Use one extra row on the outside so we have to use less rows in the inside to make for a nice visual appearance
+	const rows = $derived(getRowsFromSeats(numSeats)+1);
 
 	const maxForRows = $derived(getSeatsFromRow(rows));
 
@@ -53,9 +54,9 @@
 		let starter = 1;
 		let spotsRemoved = 0;
 
-		while (maxForRows-(getSeatsFromRow(starter+1) + spotsRemoved) >= numSeats) {
+		while (maxForRows-(dotsOnRow(starter) + spotsRemoved) >= numSeats) {
+			spotsRemoved += dotsOnRow(starter);
 			starter++;
-			spotsRemoved += getSeatsFromRow(starter+1);
 		}
 		return starter;
 	});
@@ -75,17 +76,11 @@
 		let pointIdx = 0;
 		const unsortedPoints = [];
 
-		console.log("max for rows", maxForRows)
-		console.log("starting row", startingRow)
-		console.log("fill factor", fillFactor)
-		console.log("actual spots", actualSpots)
-		console.log("num needed", numSeats)
-
-		for (let i = startingRow; i < rows && pointIdx < numSeats; i++) {
+		for (let i = startingRow; i <= rows && pointIdx < numSeats; i++) {
 			let numInRow = Math.round(fillFactor*dotsOnRow(i));
 			numInRow = Math.min(numInRow, numSeats - pointIdx);
-
-			if (i === rows-1) numInRow = numSeats - pointIdx;
+			// Put all remaining seats lost in rounding on the outside row
+			if (i === rows) numInRow = numSeats - pointIdx;
 
 			const radius = i * rowHeight;
 			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -4,8 +4,6 @@
 	import { ChartPositionStore } from '$lib/stores/Chart';
 	import { ChartLeansStore } from '$lib/stores/ChartLeansStore';
 
-	import { fade } from 'svelte/transition';
-
 	const seatRadius = 6;
 
 	const marginBetweenSeats = 2;
@@ -47,16 +45,17 @@
 
 	const numSeats = $derived([...$CandidateCounts.values()].reduce((total, cur) => total + cur, 0));
 
-	// Use one extra row on the outside so we have to use less rows in the inside to make for a nice visual appearance
-	const rows = $derived(getRowsFromSeats(numSeats)+1);
+	// Use one extra row on the outside so we have to use less rows in the inside to allow for a larger "hole" at the bottom of the chart
+	const rows = $derived(getRowsFromSeats(numSeats) + 1);
 
 	const maxForRows = $derived(getSeatsFromRow(rows));
 
+	// Remove inner rows as far as possible to push fill factor as close to 1 as possible
 	const startingRow = $derived.by(() => {
 		let starter = 1;
 		let spotsRemoved = 0;
 
-		while (maxForRows-(dotsOnRow(starter) + spotsRemoved) >= numSeats) {
+		while (maxForRows - (dotsOnRow(starter) + spotsRemoved) >= numSeats) {
 			spotsRemoved += dotsOnRow(starter);
 			starter++;
 		}
@@ -65,7 +64,7 @@
 
 	const actualSpots = $derived(maxForRows - getSeatsFromRow(startingRow));
 
-	const fillFactor = $derived(numSeats/actualSpots);
+	const fillFactor = $derived(numSeats / actualSpots);
 
 	const width = $derived(rows * 2 * rowHeight);
 
@@ -79,7 +78,7 @@
 		const unsortedPoints = [];
 
 		for (let i = startingRow; i <= rows && pointIdx < numSeats; i++) {
-			let numInRow = Math.round(fillFactor*dotsOnRow(i));
+			let numInRow = Math.round(fillFactor * dotsOnRow(i));
 			numInRow = Math.min(numInRow, numSeats - pointIdx);
 			// Put all remaining seats lost in rounding on the outside row
 			if (i === rows) numInRow = numSeats - pointIdx;
@@ -87,9 +86,9 @@
 			const radius = i * rowHeight;
 			for (let j = 0; j < numInRow && pointIdx < numSeats; j++) {
 				// Determine position along the top half of the unit circle.
-				const percentageAlongSemicircle = (j / numInRow);
+				const percentageAlongSemicircle = j / numInRow;
 				//Adjust to the midpoint of the interval from [i/numInRow, i+1/numInRow]. e.x: [0, 0.5] becomes [0.25, 0.75] for 2 points
-				const midpointOffset = (0.5 / numInRow);
+				const midpointOffset = 0.5 / numInRow;
 
 				const theta = (percentageAlongSemicircle + midpointOffset) * Math.PI;
 

--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -4,6 +4,8 @@
 	import { ChartPositionStore } from '$lib/stores/Chart';
 	import { ChartLeansStore } from '$lib/stores/ChartLeansStore';
 
+	import { fade } from 'svelte/transition';
+
 	const seatRadius = 6;
 
 	const marginBetweenSeats = 2;
@@ -138,8 +140,9 @@
 		<svg
 			viewBox={`-${width / 2 + seatRadius} -${width / 2 + seatRadius} ${width + seatRadius * 2} ${width / 2 + seatRadius * 2}`}
 		>
-			{#each points as point, idx}
+			{#each points as point, idx (idx)}
 				<circle
+					class="transition-colors"
 					r={seatRadius}
 					fill={pointColors[idx]}
 					cy={point.radius * Math.sin(point.theta) * -1}
@@ -147,9 +150,5 @@
 				></circle>
 			{/each}
 		</svg>
-		{#each Array(rows).keys() as row}
-			{dotsOnRow(row)}
-			<br>
-		{/each}
 	</div>
 </div>

--- a/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
+++ b/apps/yapms/src/lib/components/modals/optionsmodal/OptionsModal.svelte
@@ -20,7 +20,7 @@
 
 	let logos = $derived($PocketBaseStore.collection('creator_logos').getFullList());
 
-	const chartTypeValues = ['pie', 'doughnut', 'battle', 'none'];
+	const chartTypeValues = ['pie', 'doughnut', 'battle', 'arch', 'none'];
 	const chartPositionValues = ['bottom', 'left'];
 
 	function readLogoFile() {

--- a/apps/yapms/src/lib/stores/Chart.ts
+++ b/apps/yapms/src/lib/stores/Chart.ts
@@ -4,4 +4,4 @@ import { writable } from 'svelte/store';
 
 export const ChartPositionStore = writable<ChartPosition>('bottom');
 
-export const ChartTypeStore = writable<ChartType>('battle');
+export const ChartTypeStore = writable<ChartType>('arch');

--- a/apps/yapms/src/lib/stores/Chart.ts
+++ b/apps/yapms/src/lib/stores/Chart.ts
@@ -4,4 +4,4 @@ import { writable } from 'svelte/store';
 
 export const ChartPositionStore = writable<ChartPosition>('bottom');
 
-export const ChartTypeStore = writable<ChartType>('battle');
+export const ChartTypeStore = writable<ChartType>('pie');

--- a/apps/yapms/src/lib/stores/Chart.ts
+++ b/apps/yapms/src/lib/stores/Chart.ts
@@ -4,4 +4,4 @@ import { writable } from 'svelte/store';
 
 export const ChartPositionStore = writable<ChartPosition>('bottom');
 
-export const ChartTypeStore = writable<ChartType>('arch');
+export const ChartTypeStore = writable<ChartType>('battle');

--- a/apps/yapms/src/lib/stores/Chart.ts
+++ b/apps/yapms/src/lib/stores/Chart.ts
@@ -4,4 +4,4 @@ import { writable } from 'svelte/store';
 
 export const ChartPositionStore = writable<ChartPosition>('bottom');
 
-export const ChartTypeStore = writable<ChartType>('pie');
+export const ChartTypeStore = writable<ChartType>('battle');

--- a/apps/yapms/src/lib/types/ChartType.ts
+++ b/apps/yapms/src/lib/types/ChartType.ts
@@ -1,1 +1,1 @@
-export type ChartType = 'battle' | 'pie' | 'doughnut' | 'none';
+export type ChartType = 'arch' | 'battle' | 'pie' | 'doughnut' | 'none';


### PR DESCRIPTION
This PR adds an arch chart, often used for visualizing parliaments on places like Wikipedia. The chart is generated as an svg via some trigonometry. One half of candidates are placed to the right side, the other half to the left, with tossup in the middle, remaining space:

<img width="516" height="246" alt="image" src="https://github.com/user-attachments/assets/6d916518-0d8e-48b2-84ff-b2bd607c5937" />
<img width="517" height="240" alt="image" src="https://github.com/user-attachments/assets/558e4ee8-2986-4325-9983-20d5b21f0ad5" />

Like in the battle chart, leans will appear in the middle for 2 candidates. For more than 2, leans will appear left to right:

<img width="503" height="242" alt="image" src="https://github.com/user-attachments/assets/c22ab43d-0c93-49ad-bb18-18e5cdc163cc" />
<img width="531" height="248" alt="image" src="https://github.com/user-attachments/assets/3bbf59e1-e94e-4cae-beb8-6f1f7750f1d4" />
