### PR TITLE
Improve Albers USA and add 2 more composite projections

### DIFF
--- a/apps/yapms/package.json
+++ b/apps/yapms/package.json
@@ -35,6 +35,7 @@
 		"chartjs-plugin-datalabels": "2.2.0",
 		"color": "5.0.3",
 		"d3": "7.9.0",
+		"d3-composite-projections": "2.0.0",
 		"daisyui": "5.5.19",
 		"dompurify": "3.3.3",
 		"eslint": "10.1.0",

--- a/apps/yapms/src/lib/components/modals/importmodal/ProjectionOptions.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ProjectionOptions.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import {
 		geoAlbers,
-		geoAlbersUsa,
 		geoConicConformal,
 		geoConicEqualArea,
 		geoConicEquidistant,
 		geoMercator,
 		geoTransverseMercator
 	} from 'd3';
+	import * as composite from 'd3-composite-projections';
 	import { proj4ToProjection } from '$lib/utils/importMap';
 	import { ImportedSVGStore } from '$lib/stores/ImportedSVG';
 
@@ -16,9 +16,11 @@
 	const projectionOptions = [
 		{ label: 'Mercator', projectionFunction: geoMercator },
 		{ label: 'Albers', projectionFunction: geoAlbers },
-		{ label: 'Albers USA', projectionFunction: geoAlbersUsa },
+		{ label: 'Albers USA', projectionFunction: composite.geoAlbersUsaTerritories },
+		{ label: 'Albers UK', projectionFunction: composite.geoAlbersUk },
 		{ label: 'Conic Equal Area', projectionFunction: geoConicEqualArea },
 		{ label: 'Conic Conformal', projectionFunction: geoConicConformal },
+		{ label: 'Conic Conformal Europe', projectionFunction: composite.geoConicConformalEurope },
 		{ label: 'Conic Equidistant', projectionFunction: geoConicEquidistant },
 		{ label: 'Transverse Mercator', projectionFunction: geoTransverseMercator },
 		{ label: 'Custom', projectionFunction: proj4ToProjection }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "chartjs-plugin-datalabels": "2.2.0",
         "color": "5.0.3",
         "d3": "7.9.0",
+        "d3-composite-projections": "2.0.0",
         "daisyui": "5.5.19",
         "dompurify": "3.3.3",
         "eslint": "10.1.0",
@@ -174,9 +175,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -194,9 +192,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -214,9 +209,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -234,9 +226,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2173,9 +2162,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2193,9 +2179,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2213,9 +2196,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2233,9 +2213,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4042,6 +4019,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-composite-projections": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-composite-projections/-/d3-composite-projections-2.0.0.tgz",
+      "integrity": "sha512-uTxVr8j/rBMg6B/N+ESqQL1pF/wBrYISAG5nI0UNEbroSq7mIYdEb/0gOdftC/yOp0/fbITCwvf1IUsIe1JT3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/d3-geo": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "d3-path": "^3.1.0"
       }
     },
     "node_modules/d3-contour": {
@@ -6276,9 +6265,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6300,9 +6286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6324,9 +6307,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6348,9 +6328,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
This PR uses the [d3-composite-projections](https://www.npmjs.com/package/d3-composite-projections) library to show territories on the Albers USA projection and add two more projections, Albers UK (which displays the Shetlands closer to the actual UK), and Conic Conformal Europe (which shows overseas territories on the side)

d3-composite-projections is set up as a commonjs module, and so using `import *` is necessary, I fear.

Albers USA with territories
<img width="540" height="305" alt="image" src="https://github.com/user-attachments/assets/c3a9e3ea-8701-4e15-9ce4-5c9b94b4ea83" />

Albers UK vs Albers:
<img width="407" height="307" alt="image" src="https://github.com/user-attachments/assets/bae96e52-f195-4c32-8734-f63014b23507" />

Conic Conformal Europe vs Conic Conformal:
<img width="1528" height="528" alt="image" src="https://github.com/user-attachments/assets/15d255f0-bfc8-424c-94e8-48bde9b5d912" />
