### PR TITLE
Fix tossup appearing in arch chart when 0 tossup seats

### DIFF
--- a/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
+++ b/apps/yapms/src/lib/components/charts/archchart/ArchChart.svelte
@@ -26,7 +26,7 @@
 	const pointColors = $derived.by(() => {
 		if (!$ChartLeansStore.enabled) {
 			return arrangedCandidates.flatMap((c) =>
-				Array($CandidateCounts.get(c.id)).fill(c.margins[0].color)
+				Array($CandidateCounts.get(c.id) ?? 0).fill(c.margins[0].color)
 			);
 		}
 


### PR DESCRIPTION
This PR fixes an issue in the arch chart where a tossup seat would appear when the tossup candidate has 0 seats when chart tilts are not enabled:
<img width="420" height="204" alt="image" src="https://github.com/user-attachments/assets/ca561faf-7275-4562-840e-9cf8de387f19" />


This was caused by `$CandidateCounts.get(c.id)` evaluating to undefined for the tossup candidate and thus `Array(undefined)` returning an array of size 1 (`[undefined]`). By adding a fallback to 0 in case of undefined, this is fixed.