### PR TITLE
Preset Saving from Candidate Models

### DIFF
--- a/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
@@ -103,7 +103,6 @@
 	function saveAsPreset() {
 		$CustomColorsStore = [...$CustomColorsStore, newColors.map((m) => m.color)];
 		savePresetTip = 'Preset Saved!';
-		setTimeout(() => (savePresetTip = 'Save as Preset'), 1500);
 	}
 </script>
 
@@ -137,7 +136,13 @@
 					<Rotate class="size-4"></Rotate>
 				</button>
 				<div class="tooltip tooltip-right" data-tip={savePresetTip}>
-					<button class="btn btn-xs btn-circle btn-ghost" onclick={saveAsPreset}>
+					<button
+						class="btn btn-xs btn-circle btn-ghost"
+						onclick={saveAsPreset}
+						onmouseenter={() => {
+							savePresetTip = 'Save as Preset';
+						}}
+					>
 						<Swatch class="size-4"></Swatch>
 					</button>
 				</div>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/AddCandidateModal.svelte
@@ -14,6 +14,8 @@
 	import Rotate from '$lib/icons/Rotate.svelte';
 	import { flip } from 'svelte/animate';
 	import PresetColorsModal from './presetcolors/PresetColorsModal.svelte';
+	import Swatch from '$lib/icons/Swatch.svelte';
+	import { CustomColorsStore } from '$lib/stores/CustomColors';
 
 	let newName = $state<string>('New Candidate');
 	let newDefaultValue = $state<number>(0);
@@ -96,6 +98,13 @@
 	function flipColors() {
 		newColors.reverse();
 	}
+
+	let savePresetTip = $state('Save as Preset');
+	function saveAsPreset() {
+		$CustomColorsStore = [...$CustomColorsStore, newColors.map((m) => m.color)];
+		savePresetTip = 'Preset Saved!';
+		setTimeout(() => (savePresetTip = 'Save as Preset'), 1500);
+	}
 </script>
 
 <ModalBase title="Add Candidate" store={AddCandidateModalStore} onClose={close}>
@@ -122,11 +131,16 @@
 		</div>
 
 		<fieldset class="fieldset">
-			<div class="flex gap-1 items-end">
-				<legend class="fieldset-legend">Colors</legend>
+			<div class="flex items-end">
+				<legend class="fieldset-legend pr-1">Colors</legend>
 				<button class="btn btn-xs btn-circle btn-ghost" onclick={flipColors}>
 					<Rotate class="size-4"></Rotate>
 				</button>
+				<div class="tooltip tooltip-right" data-tip={savePresetTip}>
+					<button class="btn btn-xs btn-circle btn-ghost" onclick={saveAsPreset}>
+						<Swatch class="size-4"></Swatch>
+					</button>
+				</div>
 			</div>
 
 			<ul class="flex flex-row flex-wrap gap-4 justify-center" bind:this={colorList}>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import MinusCircle from '$lib/icons/MinusCircle.svelte';
 	import Rotate from '$lib/icons/Rotate.svelte';
+	import Swatch from '$lib/icons/Swatch.svelte';
 	import Trash from '$lib/icons/Trash.svelte';
 	import {
 		CandidatesStore,
 		SelectedCandidateStore,
 		TossupCandidateStore
 	} from '$lib/stores/Candidates';
+	import { CustomColorsStore } from '$lib/stores/CustomColors';
 	import { CandidateModalStore } from '$lib/stores/Modals';
 	import { EditCandidateModalStore } from '$lib/stores/Modals';
 	import { RegionsStore } from '$lib/stores/regions/Regions';
@@ -118,6 +120,16 @@
 		$CandidatesStore[candidateIndex].margins = $CandidatesStore[candidateIndex].margins.reverse();
 		$RegionsStore = $RegionsStore;
 	}
+
+	let savePresetTip = $state('Save as Preset');
+	function saveAsPreset() {
+		$CustomColorsStore = [
+			...$CustomColorsStore,
+			$CandidatesStore[candidateIndex].margins.map((m) => m.color)
+		];
+		savePresetTip = 'Preset Saved!';
+		setTimeout(() => (savePresetTip = 'Save as Preset'), 1500);
+	}
 </script>
 
 <ModalBase title="Edit Candidate" store={EditCandidateModalStore} onClose={close}>
@@ -150,11 +162,16 @@
 		</div>
 
 		<fieldset class="fieldset">
-			<div class="flex gap-1 items-end">
-				<legend class="fieldset-legend">Colors</legend>
+			<div class="flex items-end">
+				<legend class="fieldset-legend pr-1">Colors</legend>
 				<button class="btn btn-xs btn-circle btn-ghost" onclick={flipColors}>
 					<Rotate class="size-4"></Rotate>
 				</button>
+				<div class="tooltip tooltip-right" data-tip={savePresetTip}>
+					<button class="btn btn-xs btn-circle btn-ghost" onclick={saveAsPreset}>
+						<Swatch class="size-4"></Swatch>
+					</button>
+				</div>
 			</div>
 
 			<ul class="flex flex-row flex-wrap gap-4 justify-center" bind:this={colorList}>

--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
@@ -128,7 +128,6 @@
 			$CandidatesStore[candidateIndex].margins.map((m) => m.color)
 		];
 		savePresetTip = 'Preset Saved!';
-		setTimeout(() => (savePresetTip = 'Save as Preset'), 1500);
 	}
 </script>
 
@@ -168,7 +167,13 @@
 					<Rotate class="size-4"></Rotate>
 				</button>
 				<div class="tooltip tooltip-right" data-tip={savePresetTip}>
-					<button class="btn btn-xs btn-circle btn-ghost" onclick={saveAsPreset}>
+					<button
+						class="btn btn-xs btn-circle btn-ghost"
+						onclick={saveAsPreset}
+						onmouseenter={() => {
+							savePresetTip = 'Save as Preset';
+						}}
+					>
 						<Swatch class="size-4"></Swatch>
 					</button>
 				</div>


### PR DESCRIPTION
This PR adds the ability to save a candidates colors as a preset using a button in the candidate modals. Suggested by RedoxLP on Discord.

The way I do action confirmation in the modal is with a tooltip since there's no way to tell the preset has saved on the same screen otherwise.