### PR TITLE
Subdirectory support for maps

### DIFF
--- a/apps/yapms/src/routes/app/[country]/+layout.svelte
+++ b/apps/yapms/src/routes/app/[country]/+layout.svelte
@@ -16,6 +16,8 @@
 		gotoLoadedMap
 	} from '$lib/stores/LoadedMap';
 
+	let { children } = $props();
+
 	const requestedMap = $derived(page.url.pathname.replace('/app/', '').replaceAll('/', '-'));
 
 	const map = $derived.by(() => {
@@ -60,12 +62,12 @@
 	}
 </script>
 
-{#await map}
-	<div class="flex justify-center w-full h-full">
-		<span class="loading loading-ring loading-lg text-primary"></span>
-	</div>
-{:then map}
-	{#if map !== undefined}
+{#if map !== undefined}
+	{#await map}
+		<div class="flex justify-center w-full h-full">
+			<span class="loading loading-ring loading-lg text-primary"></span>
+		</div>
+	{:then map}
 		<div
 			use:setupMap
 			id="map-div"
@@ -75,11 +77,11 @@
 		>
 			{@html map}
 		</div>
-	{:else}
-		<div class="flex justify-center items-center w-full h-full">
-			<h1>Map "{requestedMap}" not found!</h1>
-		</div>
-	{/if}
-{/await}
+	{/await}
+{:else}
+	<div class="flex justify-center items-center w-full h-full">
+		<h1>Map "{requestedMap}" not found!</h1>
+	</div>
+{/if}
 
-<slot />
+{@render children()} 

--- a/apps/yapms/src/routes/app/[country]/+layout.svelte
+++ b/apps/yapms/src/routes/app/[country]/+layout.svelte
@@ -84,4 +84,4 @@
 	</div>
 {/if}
 
-{@render children()} 
+{@render children()}

--- a/apps/yapms/src/routes/app/[country]/+layout.svelte
+++ b/apps/yapms/src/routes/app/[country]/+layout.svelte
@@ -16,10 +16,17 @@
 		gotoLoadedMap
 	} from '$lib/stores/LoadedMap';
 
-	let requestedMap = $derived(page.url.pathname.replace('/app/', '').replaceAll('/', '-'));
-	let country = $derived(requestedMap.split('-').at(0));
+	const requestedMap = $derived(page.url.pathname.replace('/app/', '').replaceAll('/', '-'));
 
-	let map = $derived(import(`../../../lib/assets/maps/${country}/${requestedMap}.svg?raw`));
+	const map = $derived.by(() => {
+		const maps = import.meta.glob<string>('../../../lib/assets/maps/**/*.svg', {
+			import: 'default',
+			query: '?raw'
+		});
+		const match = Object.entries(maps).find(([path]) => path.endsWith(`/${requestedMap}.svg`));
+
+		return match !== undefined ? match[1]() : undefined;
+	});
 
 	function setupMap(node: HTMLDivElement) {
 		const svg = node.querySelector<SVGElement>('svg');
@@ -58,15 +65,21 @@
 		<span class="loading loading-ring loading-lg text-primary"></span>
 	</div>
 {:then map}
-	<div
-		use:setupMap
-		id="map-div"
-		class="overflow-hidden h-full outline-none"
-		class:insets-hidden={$MapInsetsStore.hidden}
-		class:texts-hidden={$RegionTextsStore.hidden}
-	>
-		{@html map.default}
-	</div>
+	{#if map !== undefined}
+		<div
+			use:setupMap
+			id="map-div"
+			class="overflow-hidden h-full outline-none"
+			class:insets-hidden={$MapInsetsStore.hidden}
+			class:texts-hidden={$RegionTextsStore.hidden}
+		>
+			{@html map}
+		</div>
+	{:else}
+		<div class="flex justify-center items-center w-full h-full">
+			<h1>Map "{requestedMap}" not found!</h1>
+		</div>
+	{/if}
 {/await}
 
 <slot />

--- a/apps/yapms/src/routes/app/[country]/[map]/+page.server.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/+page.server.ts
@@ -1,5 +1,5 @@
 export function entries() {
-	const maps = import.meta.glob('$lib/assets/maps/*/*.svg');
+	const maps = import.meta.glob('$lib/assets/maps/**/*.svg');
 
 	const result = [];
 	for (const key in maps) {

--- a/apps/yapms/src/routes/app/[country]/[map]/[year]/[variant]/+page.server.ts
+++ b/apps/yapms/src/routes/app/[country]/[map]/[year]/[variant]/+page.server.ts
@@ -1,5 +1,5 @@
 export function entries() {
-	const maps = import.meta.glob('$lib/assets/maps/*/*.svg');
+	const maps = import.meta.glob('$lib/assets/maps/**/*.svg');
 
 	const result = [];
 	for (const key in maps) {


### PR DESCRIPTION
This PR changes map loading to use glob imports, allowing us to have subdirectories within country map directories. This will be especially useful for US maps.

I did not include reorganization for US maps here, so to test this just drag a map into a new folder and try loading it.

I looked at performance here too. Build performance is unaffected on my end, as is page loading performance.