### PR TITLE
Make margin updating immutable

### DIFF
--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
@@ -72,10 +72,8 @@
 		event: Event & { currentTarget: EventTarget & HTMLInputElement },
 		index: number
 	) {
-		$CandidatesStore[candidateIndex].margins = $CandidatesStore[candidateIndex].margins.map((margin, i) =>
-			i === index
-				? { ...margin, color: event.currentTarget.value }
-				: margin
+		$CandidatesStore[candidateIndex].margins = $CandidatesStore[candidateIndex].margins.map(
+			(margin, i) => (i === index ? { ...margin, color: event.currentTarget.value } : margin)
 		);
 		$RegionsStore = $RegionsStore;
 		colorToDelete = undefined;

--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditCandidateModal.svelte
@@ -72,7 +72,11 @@
 		event: Event & { currentTarget: EventTarget & HTMLInputElement },
 		index: number
 	) {
-		$CandidatesStore[candidateIndex].margins[index].color = event.currentTarget.value;
+		$CandidatesStore[candidateIndex].margins = $CandidatesStore[candidateIndex].margins.map((margin, i) =>
+			i === index
+				? { ...margin, color: event.currentTarget.value }
+				: margin
+		);
 		$RegionsStore = $RegionsStore;
 		colorToDelete = undefined;
 	}

--- a/apps/yapms/src/lib/components/modals/candidatemodal/EditTossupModal.svelte
+++ b/apps/yapms/src/lib/components/modals/candidatemodal/EditTossupModal.svelte
@@ -10,7 +10,7 @@
 	}
 
 	function updateColor(event: Event & { currentTarget: EventTarget & HTMLInputElement }) {
-		$TossupCandidateStore.margins[0].color = event.currentTarget.value;
+		$TossupCandidateStore.margins = [{ color: event.currentTarget.value }];
 		$RegionsStore = $RegionsStore;
 	}
 </script>


### PR DESCRIPTION
This PR changes margin updates in the edit candidate/edit tossup modals to be immutable, fixing a bug where you would update a candidate's margins and the color boxes on the bottom of the candidate box would not update.

<img width="548" height="529" alt="yapmsCandBoxNotUpdating" src="https://github.com/user-attachments/assets/9e6bc31d-6c10-4a5a-bc61-c91bfce3f8e6" />
