### PR TITLE
Fix two mislabeled USA Historical maps

### DIFF
--- a/apps/yapms/src/lib/components/mapcard/mapcards/USACongressionalMapCard.svelte
+++ b/apps/yapms/src/lib/components/mapcard/mapcards/USACongressionalMapCard.svelte
@@ -113,12 +113,12 @@
 					route: '/app/usa/house/1985003/blank'
 				},
 				{
-					label: '1992',
+					label: '1982',
 					modalLabel: 'House 1982',
 					route: '/app/usa/house/1983003/blank'
 				},
 				{
-					label: '1990',
+					label: '1980',
 					modalLabel: 'House 1980',
 					route: '/app/usa/house/1981003/blank'
 				},


### PR DESCRIPTION
This PR fixes the 1982 & 1980 house map mistakenly being labeled as 1992 & 1990 respectively