### PR TITLE
set permaVal on save load

### DIFF
--- a/apps/yapms/src/lib/stores/LoadedMap.ts
+++ b/apps/yapms/src/lib/stores/LoadedMap.ts
@@ -175,6 +175,7 @@ export async function drawLoadedMap() {
 		return {
 			...currentRegion,
 			value: loadedRegion.value,
+			permaVal: loadedRegion.value,
 			disabled: loadedRegion.disabled,
 			locked: loadedRegion.locked,
 			permaLocked: loadedRegion.permaLocked,

--- a/apps/yapms/src/lib/stores/LoadedMap.ts
+++ b/apps/yapms/src/lib/stores/LoadedMap.ts
@@ -175,7 +175,7 @@ export async function drawLoadedMap() {
 		return {
 			...currentRegion,
 			value: loadedRegion.value,
-			permaVal: loadedRegion.value,
+			permaVal: loadedRegion.permaVal,
 			disabled: loadedRegion.disabled,
 			locked: loadedRegion.locked,
 			permaLocked: loadedRegion.permaLocked,


### PR DESCRIPTION
This PR fixes an issue where edited region values would not show up in the regions table right when loading a save, since the regions table uses permaVal as it's binded value and permaVal was not being set on save load.

Steps to reproduce the bug:
- Open a map and edit some region values
- Save the map and then load the saved map (maybe with a refresh in the middle)
- Go into the regions table, search for the region yo uedited, see it's value has not updated