### PR TITLE
Accept SVG on iOS

### DIFF
--- a/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
+++ b/apps/yapms/src/lib/components/modals/importmodal/ImportModal.svelte
@@ -97,7 +97,7 @@
 						<input
 							multiple
 							type="file"
-							accept=".geojson, .json, .svg, .shp"
+							accept=".geojson, .json, image/svg+xml, .svg, .shp"
 							class="file-input w-full"
 							class:file-input-error={errorLoading || fileTypeIsInvalid}
 							disabled={isLoading}


### PR DESCRIPTION
This PR attempts to fix the issue people have been having on iOS where they cannot import SVGs by adding a more explicit allow of a MIME type.

Cannot reproduce the issue on my partner's phone, but can verify this doesn't break anything.